### PR TITLE
Update ember-firebase-service to v8.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,7 @@
 'use strict';
 
 const Config = require('./lib/config');
-const Funnel = require('broccoli-funnel');
 const MergeTrees = require('broccoli-merge-trees');
-const fastbootTransform = require('fastboot-transform');
 
 module.exports = {
   name: 'ember-cloud-firestore-adapter',
@@ -21,8 +19,8 @@ module.exports = {
 
     this.serviceWorkerOption = Object.assign({}, this.serviceWorkerOption, { firebaseConfig });
 
-    app.import('vendor/fastboot-shims/firebase/firebase-auth.js');
-    app.import('vendor/fastboot-shims/firebase/firebase-firestore.js');
+    app.import('vendor/ember-firebase-service/firebase/firebase-auth.js');
+    app.import('vendor/ember-firebase-service/firebase/firebase-firestore.js');
 
     if (app.env !== 'production') {
       app.import('node_modules/mock-cloud-firestore/dist/mock-cloud-firestore.js');
@@ -34,14 +32,5 @@ module.exports = {
     const configFile = new Config([appTree], this.serviceWorkerOption);
 
     return new MergeTrees([swTree, configFile]);
-  },
-
-  treeForVendor(defaultTree) {
-    const browserVendorLib = new Funnel('node_modules', {
-      destDir: 'fastboot-shims',
-      files: ['firebase/firebase-auth.js', 'firebase/firebase-firestore.js'],
-    });
-
-    return new MergeTrees([defaultTree, fastbootTransform(browserVendorLib)]);
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cloud-firestore-adapter",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6839,16 +6839,16 @@
       }
     },
     "@firebase/analytics": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.6.0.tgz",
-      "integrity": "sha512-6qYEOPUVYrMhqvJ46Z5Uf1S4uULd6d7vGpMP5Qz+u8kIWuOQGcPdJKQap+Hla6Rq164or9gC2HRXuYXKlgWfpw==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.6.1.tgz",
+      "integrity": "sha512-Pn7KPkH/M2JXoyoDHfdSjTBHTlnqe6rHo/vjsSvveA46dUP/GfDpcKWGfy/OBXKrIvKUVP7ZhyZo0Gb6jKB0cw==",
       "dev": true,
       "requires": {
         "@firebase/analytics-types": "0.4.0",
-        "@firebase/component": "0.1.19",
-        "@firebase/installations": "0.4.17",
+        "@firebase/component": "0.1.20",
+        "@firebase/installations": "0.4.18",
         "@firebase/logger": "0.2.6",
-        "@firebase/util": "0.3.2",
+        "@firebase/util": "0.3.3",
         "tslib": "^1.11.1"
       },
       "dependencies": {
@@ -6867,15 +6867,15 @@
       "dev": true
     },
     "@firebase/app": {
-      "version": "0.6.11",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.6.11.tgz",
-      "integrity": "sha512-FH++PaoyTzfTAVuJ0gITNYEIcjT5G+D0671La27MU8Vvr6MTko+5YUZ4xS9QItyotSeRF4rMJ1KR7G8LSyySiA==",
+      "version": "0.6.12",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.6.12.tgz",
+      "integrity": "sha512-gko1NxRLJn+BMqDK6GBhcCDApD5rX5zhNfS7frl/uic8us9GnAuo6NtHuO0Q+AAjYB1Sv3YtPLXI7ckQEO9Wew==",
       "dev": true,
       "requires": {
         "@firebase/app-types": "0.6.1",
-        "@firebase/component": "0.1.19",
+        "@firebase/component": "0.1.20",
         "@firebase/logger": "0.2.6",
-        "@firebase/util": "0.3.2",
+        "@firebase/util": "0.3.3",
         "dom-storage": "2.1.0",
         "tslib": "^1.11.1",
         "xmlhttprequest": "1.8.0"
@@ -6896,9 +6896,9 @@
       "dev": true
     },
     "@firebase/auth": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.15.0.tgz",
-      "integrity": "sha512-IFuzhxS+HtOQl7+SZ/Mhaghy/zTU7CENsJFWbC16tv2wfLZbayKF5jYGdAU3VFLehgC8KjlcIWd10akc3XivfQ==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.15.1.tgz",
+      "integrity": "sha512-qVJTmq/6l3/o6V93nAD+n1ExTywbKEFYbuuI1TZIUryy5KSXOFnxilmZI4yJeQSZ3ee06YiJsIRYRaYUeg6JQQ==",
       "dev": true,
       "requires": {
         "@firebase/auth-types": "0.10.1"
@@ -6917,12 +6917,12 @@
       "dev": true
     },
     "@firebase/component": {
-      "version": "0.1.19",
-      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.19.tgz",
-      "integrity": "sha512-L0S3g8eqaerg8y0zox3oOHSTwn/FE8RbcRHiurnbESvDViZtP5S5WnhuAPd7FnFxa8ElWK0z1Tr3ikzWDv1xdQ==",
+      "version": "0.1.20",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.20.tgz",
+      "integrity": "sha512-UF9kBCco3U5AMJVNrup8kzOjksvmjmwL88vr/cL3BQ7DeTZWMf15iBOmBf+9HnhtPboN8Cw+84VT21aXGHBgNQ==",
       "dev": true,
       "requires": {
-        "@firebase/util": "0.3.2",
+        "@firebase/util": "0.3.3",
         "tslib": "^1.11.1"
       },
       "dependencies": {
@@ -6935,16 +6935,16 @@
       }
     },
     "@firebase/database": {
-      "version": "0.6.13",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.6.13.tgz",
-      "integrity": "sha512-NommVkAPzU7CKd1gyehmi3lz0K78q0KOfiex7Nfy7MBMwknLm7oNqKovXSgQV1PCLvKXvvAplDSFhDhzIf9obA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.7.0.tgz",
+      "integrity": "sha512-pVio41uGhy6HNSk1uBHq9wTzO83bg2Jb527XFILIk4p/KFBbuQwKnQn+65SfnsDlElC1HjHBerTaonHLYevJqA==",
       "dev": true,
       "requires": {
         "@firebase/auth-interop-types": "0.1.5",
-        "@firebase/component": "0.1.19",
-        "@firebase/database-types": "0.5.2",
+        "@firebase/component": "0.1.20",
+        "@firebase/database-types": "0.6.0",
         "@firebase/logger": "0.2.6",
-        "@firebase/util": "0.3.2",
+        "@firebase/util": "0.3.3",
         "faye-websocket": "0.11.3",
         "tslib": "^1.11.1"
       },
@@ -6958,24 +6958,24 @@
       }
     },
     "@firebase/database-types": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.5.2.tgz",
-      "integrity": "sha512-ap2WQOS3LKmGuVFKUghFft7RxXTyZTDr0Xd8y2aqmWsbJVjgozi0huL/EUMgTjGFrATAjcf2A7aNs8AKKZ2a8g==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.6.0.tgz",
+      "integrity": "sha512-ljpU7/uboCGqFSe9CNgwd3+Xu5N8YCunzfPpeueuj2vjnmmypUi4QWxgC3UKtGbuv1q+crjeudZGLxnUoO0h7w==",
       "dev": true,
       "requires": {
         "@firebase/app-types": "0.6.1"
       }
     },
     "@firebase/firestore": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-1.18.0.tgz",
-      "integrity": "sha512-maMq4ltkrwjDRusR2nt0qS4wldHQMp+0IDSfXIjC+SNmjnWY/t/+Skn9U3Po+dB38xpz3i7nsKbs+8utpDnPSw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-2.0.0.tgz",
+      "integrity": "sha512-KHp5/yRmdQkpfGg8zotTJlUweXVsTe6Ip68iruc51VhYjWgmIb5QorelE1N5+O3kFqiDTOfBfeCXaO14bXk4wA==",
       "dev": true,
       "requires": {
-        "@firebase/component": "0.1.19",
-        "@firebase/firestore-types": "1.14.0",
+        "@firebase/component": "0.1.20",
+        "@firebase/firestore-types": "2.0.0",
         "@firebase/logger": "0.2.6",
-        "@firebase/util": "0.3.2",
+        "@firebase/util": "0.3.3",
         "@firebase/webchannel-wrapper": "0.4.0",
         "@grpc/grpc-js": "^1.0.0",
         "@grpc/proto-loader": "^0.5.0",
@@ -6998,19 +6998,19 @@
       }
     },
     "@firebase/firestore-types": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-1.14.0.tgz",
-      "integrity": "sha512-WF8IBwHzZDhwyOgQnmB0pheVrLNP78A8PGxk1nxb/Nrgh1amo4/zYvFMGgSsTeaQK37xMYS/g7eS948te/dJxw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-2.0.0.tgz",
+      "integrity": "sha512-ZGb7p1SSQJP0Z+kc9GAUi+Fx5rJatFddBrS1ikkayW+QHfSIz0omU23OgSHcBGTxe8dJCeKiKA2Yf+tkDKO/LA==",
       "dev": true
     },
     "@firebase/functions": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.5.1.tgz",
-      "integrity": "sha512-yyjPZXXvzFPjkGRSqFVS5Hc2Y7Y48GyyMH+M3i7hLGe69r/59w6wzgXKqTiSYmyE1pxfjxU4a1YqBDHNkQkrYQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.6.0.tgz",
+      "integrity": "sha512-XDVyDLBJwGCqI/agGxRrPYfit7HTcOSXTrjlC8NJr5+h3zzUuAB/+VEfaa8mSEZR+0AjY67B1cPed0WuXsU48g==",
       "dev": true,
       "requires": {
-        "@firebase/component": "0.1.19",
-        "@firebase/functions-types": "0.3.17",
+        "@firebase/component": "0.1.20",
+        "@firebase/functions-types": "0.4.0",
         "@firebase/messaging-types": "0.5.0",
         "node-fetch": "2.6.1",
         "tslib": "^1.11.1"
@@ -7031,20 +7031,20 @@
       }
     },
     "@firebase/functions-types": {
-      "version": "0.3.17",
-      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.3.17.tgz",
-      "integrity": "sha512-DGR4i3VI55KnYk4IxrIw7+VG7Q3gA65azHnZxo98Il8IvYLr2UTBlSh72dTLlDf25NW51HqvJgYJDKvSaAeyHQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.4.0.tgz",
+      "integrity": "sha512-3KElyO3887HNxtxNF1ytGFrNmqD+hheqjwmT3sI09FaDCuaxGbOnsXAXH2eQ049XRXw9YQpHMgYws/aUNgXVyQ==",
       "dev": true
     },
     "@firebase/installations": {
-      "version": "0.4.17",
-      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.4.17.tgz",
-      "integrity": "sha512-AE/TyzIpwkC4UayRJD419xTqZkKzxwk0FLht3Dci8WI2OEKHSwoZG9xv4hOBZebe+fDzoV2EzfatQY8c/6Avig==",
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.4.18.tgz",
+      "integrity": "sha512-el1PvpVbsNb6uXIoSKzI0A52K+h8yeLvI1tjMqdjnp+0xZQr2pwRJcBMvzt6aLrgBT06jMVB3R+fxfxxqgoO2g==",
       "dev": true,
       "requires": {
-        "@firebase/component": "0.1.19",
+        "@firebase/component": "0.1.20",
         "@firebase/installations-types": "0.3.4",
-        "@firebase/util": "0.3.2",
+        "@firebase/util": "0.3.3",
         "idb": "3.0.2",
         "tslib": "^1.11.1"
       },
@@ -7070,15 +7070,15 @@
       "dev": true
     },
     "@firebase/messaging": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.7.1.tgz",
-      "integrity": "sha512-iev/ST9v0xd/8YpGYrZtDcqdD9J6ZWzSuceRn8EKy5vIgQvW/rk2eTQc8axzvDpQ36ZfphMYuhW6XuNrR3Pd2Q==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.7.2.tgz",
+      "integrity": "sha512-5FzxklNgZS5S03p0eKvhsj6mLGG06qgnaLEbLluKeuDJ5STR/+gWySuCdP9BhcJCsTGN77Qwa06MLK/d46R0rQ==",
       "dev": true,
       "requires": {
-        "@firebase/component": "0.1.19",
-        "@firebase/installations": "0.4.17",
+        "@firebase/component": "0.1.20",
+        "@firebase/installations": "0.4.18",
         "@firebase/messaging-types": "0.5.0",
-        "@firebase/util": "0.3.2",
+        "@firebase/util": "0.3.3",
         "idb": "3.0.2",
         "tslib": "^1.11.1"
       },
@@ -7098,16 +7098,16 @@
       "dev": true
     },
     "@firebase/performance": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.4.2.tgz",
-      "integrity": "sha512-irHTCVWJ/sxJo0QHg+yQifBeVu8ZJPihiTqYzBUz/0AGc51YSt49FZwqSfknvCN2+OfHaazz/ARVBn87g7Ex8g==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.4.3.tgz",
+      "integrity": "sha512-oP7EvI8qvlAJgVGY25ZabXl/Xb82ykxKyYP+xNDs0Imdg+8GBOfzqQiGpM+BqovhTTdGPcpJmry7JYwpWMZ8bg==",
       "dev": true,
       "requires": {
-        "@firebase/component": "0.1.19",
-        "@firebase/installations": "0.4.17",
+        "@firebase/component": "0.1.20",
+        "@firebase/installations": "0.4.18",
         "@firebase/logger": "0.2.6",
         "@firebase/performance-types": "0.0.13",
-        "@firebase/util": "0.3.2",
+        "@firebase/util": "0.3.3",
         "tslib": "^1.11.1"
       },
       "dependencies": {
@@ -7151,16 +7151,16 @@
       }
     },
     "@firebase/remote-config": {
-      "version": "0.1.28",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.1.28.tgz",
-      "integrity": "sha512-4zSdyxpt94jAnFhO8toNjG8oMKBD+xTuBIcK+Nw8BdQWeJhEamgXlupdBARUk1uf3AvYICngHH32+Si/dMVTbw==",
+      "version": "0.1.29",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.1.29.tgz",
+      "integrity": "sha512-VuKoubiE/kEfp5FXx7Nxw5c1TRYApBey7zdwTu/+U7qZFofHnUGDZs1vu82xTRnwbPtxh228FOwpZZ0iTrpVtA==",
       "dev": true,
       "requires": {
-        "@firebase/component": "0.1.19",
-        "@firebase/installations": "0.4.17",
+        "@firebase/component": "0.1.20",
+        "@firebase/installations": "0.4.18",
         "@firebase/logger": "0.2.6",
         "@firebase/remote-config-types": "0.1.9",
-        "@firebase/util": "0.3.2",
+        "@firebase/util": "0.3.3",
         "tslib": "^1.11.1"
       },
       "dependencies": {
@@ -7179,14 +7179,14 @@
       "dev": true
     },
     "@firebase/storage": {
-      "version": "0.3.43",
-      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.3.43.tgz",
-      "integrity": "sha512-Jp54jcuyimLxPhZHFVAhNbQmgTu3Sda7vXjXrNpPEhlvvMSq4yuZBR6RrZxe/OrNVprLHh/6lTCjwjOVSo3bWA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.4.0.tgz",
+      "integrity": "sha512-6AG1g2WbbVxscf40rHar+IAk6ocvg8IOM5NmlXHxcXt9KENSQYGNiHsGEROm+W7FOx2izuHTEfqPUr8Qh5EwNA==",
       "dev": true,
       "requires": {
-        "@firebase/component": "0.1.19",
+        "@firebase/component": "0.1.20",
         "@firebase/storage-types": "0.3.13",
-        "@firebase/util": "0.3.2",
+        "@firebase/util": "0.3.3",
         "tslib": "^1.11.1"
       },
       "dependencies": {
@@ -7205,9 +7205,9 @@
       "dev": true
     },
     "@firebase/util": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.3.2.tgz",
-      "integrity": "sha512-Dqs00++c8rwKky6KCKLLY2T1qYO4Q+X5t+lF7DInXDNF4ae1Oau35bkD+OpJ9u7l1pEv7KHowP6CUKuySCOc8g==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.3.3.tgz",
+      "integrity": "sha512-VBuyR+6QAvrumzEtp3hMTRYkDnvsWuDMzqObca2Phn30RJTEV24P1RSMG5fw8LbSE+KkD9WiiiMJN++YoeyFaA==",
       "dev": true,
       "requires": {
         "tslib": "^1.11.1"
@@ -10865,6 +10865,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/broccoli-stew/-/broccoli-stew-1.6.0.tgz",
       "integrity": "sha512-sUwCJNnYH4Na690By5xcEMAZqKgquUQnMAEuIiL3Z2k63mSw9Xg+7Ew4wCrFrMmXMcLpWjZDOm6Yqnq268N+ZQ==",
+      "dev": true,
       "requires": {
         "broccoli-debug": "^0.6.1",
         "broccoli-funnel": "^2.0.0",
@@ -10886,6 +10887,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.1.tgz",
           "integrity": "sha512-WjaexJ+I8BxP5V5RNn6um/qDRSmKoiBC/QkRi79FT9ClHfldxRyCDs9mcV7mmoaPlsshmmPaUz5jdtcKA6DClQ==",
+          "dev": true,
           "requires": {
             "broccoli-plugin": "^1.3.0",
             "merge-trees": "^1.0.1"
@@ -10895,6 +10897,7 @@
           "version": "1.4.6",
           "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.6.tgz",
           "integrity": "sha512-0RejLwoC95kv4kta8KAa+FmECJCK78Qgm8SRDEK7YyU0N9Cx6KpY3UCDy9WELl3mCXLN8TokNxc7/hp3lL4lfw==",
+          "dev": true,
           "requires": {
             "async-disk-cache": "^1.2.1",
             "async-promise-queue": "^1.0.3",
@@ -10914,7 +10917,8 @@
             "rsvp": {
               "version": "3.6.2",
               "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-              "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
+              "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
+              "dev": true
             }
           }
         },
@@ -10922,6 +10926,7 @@
           "version": "3.2.6",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -10930,6 +10935,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-1.0.1.tgz",
           "integrity": "sha1-zL5nRWl4f53vF/1G5lJfVwC70j4=",
+          "dev": true,
           "requires": {
             "can-symlink": "^1.0.0",
             "fs-tree-diff": "^0.5.4",
@@ -12172,6 +12178,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
       "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.1"
       }
@@ -15486,9 +15493,9 @@
       }
     },
     "ember-firebase-service": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/ember-firebase-service/-/ember-firebase-service-7.0.0.tgz",
-      "integrity": "sha512-0iBqadP8LdHKyC3TxaZOy0mop39bM3VHpCFoOcqbYExzy3m/s79nHr6uDoqoqPPe8eBqSE4FOwm6qztFyQpjog==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/ember-firebase-service/-/ember-firebase-service-8.0.0.tgz",
+      "integrity": "sha512-XT2fIYFcjdXZaRvt3opLzubB35z+GMSGsgzySSo4PLGKI+qUwS1l9bDevSp3EFh9PsF9ldESXMxY/BVpX1AroQ==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.22.1",
@@ -15584,9 +15591,9 @@
           }
         },
         "execa": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
-          "integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+          "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
           "dev": true,
           "requires": {
             "cross-spawn": "^7.0.0",
@@ -18306,6 +18313,7 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/fastboot-transform/-/fastboot-transform-0.1.3.tgz",
       "integrity": "sha512-6otygPIJw1ARp1jJb+6KVO56iKBjhO+5x59RSC9qiZTbZRrv+HZAuP00KD3s+nWMvcFDemtdkugki9DNFTTwCQ==",
+      "dev": true,
       "requires": {
         "broccoli-stew": "^1.5.0",
         "convert-source-map": "^1.5.1"
@@ -18599,25 +18607,25 @@
       }
     },
     "firebase": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-7.24.0.tgz",
-      "integrity": "sha512-j6jIyGFFBlwWAmrlUg9HyQ/x+YpsPkc/TTkbTyeLwwAJrpAmmEHNPT6O9xtAnMV4g7d3RqLL/u9//aZlbY4rQA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-8.0.0.tgz",
+      "integrity": "sha512-0JMwNGg5CeoYBJ27QuDYJe1pYdJ+lspKbK1Pr+aNtYBfJfZTNy265rRroQsSOTGbXiT6cUqObVPeGwnbi8wZHw==",
       "dev": true,
       "requires": {
-        "@firebase/analytics": "0.6.0",
-        "@firebase/app": "0.6.11",
+        "@firebase/analytics": "0.6.1",
+        "@firebase/app": "0.6.12",
         "@firebase/app-types": "0.6.1",
-        "@firebase/auth": "0.15.0",
-        "@firebase/database": "0.6.13",
-        "@firebase/firestore": "1.18.0",
-        "@firebase/functions": "0.5.1",
-        "@firebase/installations": "0.4.17",
-        "@firebase/messaging": "0.7.1",
-        "@firebase/performance": "0.4.2",
+        "@firebase/auth": "0.15.1",
+        "@firebase/database": "0.7.0",
+        "@firebase/firestore": "2.0.0",
+        "@firebase/functions": "0.6.0",
+        "@firebase/installations": "0.4.18",
+        "@firebase/messaging": "0.7.2",
+        "@firebase/performance": "0.4.3",
         "@firebase/polyfill": "0.3.36",
-        "@firebase/remote-config": "0.1.28",
-        "@firebase/storage": "0.3.43",
-        "@firebase/util": "0.3.2"
+        "@firebase/remote-config": "0.1.29",
+        "@firebase/storage": "0.4.0",
+        "@firebase/util": "0.3.3"
       }
     },
     "fireworm": {
@@ -18847,6 +18855,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
       "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -19048,9 +19057,9 @@
       }
     },
     "gaxios": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.0.0.tgz",
-      "integrity": "sha512-Ge+S+8L8xe/LAjC2tHXFuBMVhjjm4sMevjEHshJeMZ0d37fspa9BO8WEMlYxk4lyydR/v63iHWZZ1Ri7hAqzSg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.0.1.tgz",
+      "integrity": "sha512-jOin8xRZ/UytQeBpSXFqIzqU7Fi5TqgPNLlUsSB8kjJ76+FiGBfImF8KJu++c6J4jOldfJUtt0YmkRj2ZpSHTQ==",
       "dev": true,
       "requires": {
         "abort-controller": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cloud-firestore-adapter",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Unofficial Ember Data Adapter and Serializer for Cloud Firestore",
   "keywords": [
     "ember-addon",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "dependencies": {
     "ember-cli-babel": "^7.22.1",
     "ember-cli-htmlbars": "^5.3.1",
-    "fastboot-transform": "^0.1.3",
     "mock-cloud-firestore": "^0.9.2"
   },
   "devDependencies": {
@@ -48,7 +47,7 @@
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.1",
     "ember-fetch": "^6.7.0",
-    "ember-firebase-service": "^7.0.0",
+    "ember-firebase-service": "^8.0.0",
     "ember-load-initializers": "^2.1.1",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^4.6.0",
@@ -64,15 +63,14 @@
     "eslint-plugin-ember": "^9.3.0",
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-node": "^11.1.0",
-    "firebase": "^7.24.0",
+    "firebase": "^8.0.0",
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "qunit-dom": "^1.5.0"
   },
   "peerDependencies": {
-    "ember-firebase-service": "^7.0.0",
-    "ember-simple-auth": "^3.0.1",
-    "firebase": "^7.24.0"
+    "ember-firebase-service": "^8.0.0",
+    "ember-simple-auth": "^3.0.1"
   },
   "engines": {
     "node": "10.* || >= 12"

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -22,6 +22,10 @@ module.exports = function(environment) {
       // when it is created
     },
 
+    fastboot: {
+      hostWhitelist: [/^localhost:\d+$/],
+    },
+
     firebase: {
       apiKey: 'AIzaSyCmI9nP62JwpZbgGYbnJtLu7gyJDXdZkk8',
       authDomain: 'rmmmp-playground.firebaseapp.com',


### PR DESCRIPTION
This PR updates `ember-firebase-service` to `v8.0.0`. This is considered a breaking change as the addon will now leverage the FastBoot friendly `firebase-<product>.js` modules provided for free by `ember-firebase-service`. Since these files didn't exist before, using `ember-firebase-service` below `v8.0.0` will prevent this addon from working.