### PR TITLE
Allow use of Firestore Emulator

### DIFF
--- a/addon/adapters/cloud-firestore.js
+++ b/addon/adapters/cloud-firestore.js
@@ -15,6 +15,10 @@ export default class CloudFirestoreAdapter extends Adapter {
 
   firestoreSettings = null;
 
+  useEmulator = false;
+
+  emulatorSettings = {};
+
   referenceKeyName = 'referenceTo';
 
   get isFasboot() {
@@ -30,6 +34,13 @@ export default class CloudFirestoreAdapter extends Adapter {
       const db = this.firebase.firestore();
 
       db.settings(this.firestoreSettings);
+    }
+
+    if (this.useEmulator) {
+      const db = this.firebase.firestore();
+      const {host, port} = emulatorSettings;
+
+      db.useEmulator && db.useEmulator(host || 'localhost', Number(port) || 8080);
     }
 
     this.realtimeTracker = new RealtimeTracker();

--- a/addon/adapters/cloud-firestore.js
+++ b/addon/adapters/cloud-firestore.js
@@ -13,14 +13,6 @@ import RealtimeTracker from 'ember-cloud-firestore-adapter/utils/realtime-tracke
 export default class CloudFirestoreAdapter extends Adapter {
   @service firebase;
 
-  firestoreSettings = null;
-
-  useEmulator = false;
-
-  emulatorSettings = {};
-
-  referenceKeyName = 'referenceTo';
-
   get isFasboot() {
     const fastboot = getOwner(this).lookup('service:fastboot');
 
@@ -38,9 +30,15 @@ export default class CloudFirestoreAdapter extends Adapter {
 
     if (this.useEmulator) {
       const db = this.firebase.firestore();
-      const {host, port} = emulatorSettings;
+      const { host, port } = this.emulatorSettings || { host: 'localhost', port: 8080 };
 
-      db.useEmulator && db.useEmulator(host || 'localhost', Number(port) || 8080);
+      if (db.useEmulator) {
+        db.useEmulator(host, Number(port));
+      }
+    }
+
+    if (!this.referenceKeyName) {
+      this.referenceKeyName = 'referenceTo';
     }
 
     this.realtimeTracker = new RealtimeTracker();


### PR DESCRIPTION
users can pass a `useEmulator` boolean during adapter creation to specify that the firebase client sdk talk to a local emulator. 

An optional `emulatorSettings: {host: string, port: number}` can also be passed instead of the default values of `'localhost'` and `8080` respectively.

The `useEmulator` method was added in v8.0.0 of the client SDK. This PR allows for that and users can also use the existing `firestoreSettings` to set the value if using < 8.0.0
