### PR TITLE
Support the Firebase auth service emulator

### DIFF
--- a/addon/instance-initializers/firebase-settings.ts
+++ b/addon/instance-initializers/firebase-settings.ts
@@ -12,9 +12,12 @@ export function initialize(appInstance: ApplicationInstance): void {
     }
 
     if (config['ember-cloud-firestore-adapter']?.emulator) {
-      const { hostname, port, authPort } = config['ember-cloud-firestore-adapter'].emulator;
+      const {
+        hostname, port, firestorePort, authPort,
+      } = config['ember-cloud-firestore-adapter'].emulator;
 
-      db.useEmulator(hostname, port);
+      // retain "port" as fallback for backwards compat
+      db.useEmulator(hostname, firestorePort || port);
       if (authPort) {
         // for some reason the auth().useEmulator requires a string url, rather
         // than (hostname, port), even though it seems only localhost-over-HTTP is

--- a/addon/instance-initializers/firebase-settings.ts
+++ b/addon/instance-initializers/firebase-settings.ts
@@ -12,9 +12,18 @@ export function initialize(appInstance: ApplicationInstance): void {
     }
 
     if (config['ember-cloud-firestore-adapter']?.emulator) {
-      const { hostname, port } = config['ember-cloud-firestore-adapter'].emulator;
+      const { hostname, port, authPort } = config['ember-cloud-firestore-adapter'].emulator;
 
       db.useEmulator(hostname, port);
+      if (authPort) {
+        // for some reason the auth().useEmulator requires a string url, rather
+        // than (hostname, port), even though it seems only localhost-over-HTTP is
+        // supported: https://github.com/firebase/firebase-js-sdk/issues/4124
+        //
+        // https://firebase.google.com/docs/emulator-suite/connect_auth#android_ios_and_web_sdks
+        // https://firebase.google.com/docs/reference/js/firebase.auth.Auth#useemulator
+        firebase.auth().useEmulator(`http://${hostname}:${authPort}`);
+      }
     }
   } catch (e) {
     if (e.name === 'FirebaseError' && e.code === 'failed-precondition') {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -45,6 +45,7 @@ let ENV = {
     emulator: {
       hostname: 'localhost',
       port: 8080,
+      authPort: 9099  // optional if not using auth
     },
   },
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -44,7 +44,7 @@ let ENV = {
   'ember-cloud-firestore-adapter': {
     emulator: {
       hostname: 'localhost',
-      port: 8080,
+      firestorePort: 8080,
       authPort: 9099  // optional if not using auth
     },
   },

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -14,6 +14,7 @@ let ENV = {
     emulator: {
       hostname: 'localhost',
       port: 8080,
+      authPort: 9099  // optional if not using auth
     },
   },
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -13,7 +13,7 @@ let ENV = {
   'ember-cloud-firestore-adapter': {
     emulator: {
       hostname: 'localhost',
-      port: 8080,
+      firestorePort: 8080,
       authPort: 9099  // optional if not using auth
     },
   },

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -38,7 +38,7 @@ module.exports = function(environment) {
     'ember-cloud-firestore-adapter': {
       emulator: {
         hostname: 'localhost',
-        port: 8080,
+        firestorePort: 8080,
       },
     },
   };


### PR DESCRIPTION
This adds (optional) support for the firebase auth service emulator. Currently ember-cloud-firestore-adapter seems to support the firestore emulator, and supports auth using the live service, but afaict the auth emulator isn't supported. 

The name of the firestore emulator port is changed to `firestorePort` for consistency, but the existing name (`port`) is still supported for backwards compatibility