### PR TITLE
[Redo] QUnit `equal` -> `strictEqual`

### DIFF
--- a/tests/acceptance/features-test.ts
+++ b/tests/acceptance/features-test.ts
@@ -86,7 +86,7 @@ module('Acceptance | features', function (hooks) {
 
     const createdRecord = await db.doc('posts/new_post').get();
 
-    assert.equal(createdRecord.get('publisher').path, 'publishers/user_a');
+    assert.strictEqual(createdRecord.get('publisher').path, 'publishers/user_a');
   });
 
   test('should update record', async function (assert) {

--- a/tests/unit/-private/build-collection-name-test.ts
+++ b/tests/unit/-private/build-collection-name-test.ts
@@ -6,6 +6,6 @@ module('Unit | -Private | build-collection-name', function () {
   test('should return the camelize and pluralize name of the string', function (assert) {
     const result = buildCollectionName('blog-post');
 
-    assert.equal(result, 'blogPosts');
+    assert.strictEqual(result, 'blogPosts');
   });
 });

--- a/tests/unit/-private/realtime-tracker-modular-test.ts
+++ b/tests/unit/-private/realtime-tracker-modular-test.ts
@@ -53,7 +53,7 @@ module('Unit | -Private | realtime-tracker-modular', function (hooks) {
 
       // Assert
       setTimeout(() => {
-        assert.equal(store.peekRecord('user', 'user_a'), null);
+        assert.strictEqual(store.peekRecord('user', 'user_a'), null);
         done();
       }, 500);
     });
@@ -104,7 +104,7 @@ module('Unit | -Private | realtime-tracker-modular', function (hooks) {
 
         // Assert
         setTimeout(() => {
-          assert.equal(store.peekRecord('user', 'user_a').name, newName);
+          assert.strictEqual(store.peekRecord('user', 'user_a').name, newName);
           done();
         }, 500);
       }, 500);
@@ -155,7 +155,7 @@ module('Unit | -Private | realtime-tracker-modular', function (hooks) {
 
         // Assert
         setTimeout(() => {
-          assert.equal(store.peekRecord('user', 'user_a'), null);
+          assert.strictEqual(store.peekRecord('user', 'user_a'), null);
           done();
         }, 500);
       }, 500);

--- a/tests/unit/-private/realtime-tracker-modular-test.ts
+++ b/tests/unit/-private/realtime-tracker-modular-test.ts
@@ -66,7 +66,7 @@ module('Unit | -Private | realtime-tracker-modular', function (hooks) {
       const store = this.owner.lookup('service:store');
       const realtimeTracker = new RealtimeTracker(store);
       const docRef = doc(db, 'users/user_a');
-      const newName = Math.random();
+      const newName = Math.random().toString();
       const storeFixture = {
         data: {
           id: 'user_a',

--- a/tests/unit/-private/realtime-tracker-test.ts
+++ b/tests/unit/-private/realtime-tracker-test.ts
@@ -57,7 +57,7 @@ module('Unit | -Private | realtime-tracker', function (hooks) {
       const store = this.owner.lookup('service:store');
       const realtimeTracker = new RealtimeTracker(store);
       const docRef = db.doc('users/user_a');
-      const newName = Math.random();
+      const newName = Math.random().toString();
       const storeFixture = {
         data: {
           id: 'user_a',

--- a/tests/unit/-private/realtime-tracker-test.ts
+++ b/tests/unit/-private/realtime-tracker-test.ts
@@ -44,7 +44,7 @@ module('Unit | -Private | realtime-tracker', function (hooks) {
 
       // Assert
       setTimeout(() => {
-        assert.equal(store.peekRecord('user', 'user_a'), null);
+        assert.strictEqual(store.peekRecord('user', 'user_a'), null);
         done();
       }, 500);
     });
@@ -95,7 +95,7 @@ module('Unit | -Private | realtime-tracker', function (hooks) {
 
         // Assert
         setTimeout(() => {
-          assert.equal(store.peekRecord('user', 'user_a').name, newName);
+          assert.strictEqual(store.peekRecord('user', 'user_a').name, newName);
           done();
         }, 500);
       }, 500);
@@ -146,7 +146,7 @@ module('Unit | -Private | realtime-tracker', function (hooks) {
 
         // Assert
         setTimeout(() => {
-          assert.equal(store.peekRecord('user', 'user_a'), null);
+          assert.strictEqual(store.peekRecord('user', 'user_a'), null);
           done();
         }, 500);
       }, 500);

--- a/tests/unit/adapters/cloud-firestore-modular-test.ts
+++ b/tests/unit/adapters/cloud-firestore-modular-test.ts
@@ -40,7 +40,7 @@ module('Unit | Adapter | cloud firestore modular', function (hooks) {
       const result = adapter.generateIdForRecord({}, 'foo');
 
       // Assert
-      assert.equal(typeof result, 'string');
+      assert.strictEqual(typeof result, 'string');
     });
   });
 
@@ -58,7 +58,7 @@ module('Unit | Adapter | cloud firestore modular', function (hooks) {
       const result = await adapter.createRecord(store, modelClass, snapshot);
 
       // Assert
-      assert.equal(result, 'foo');
+      assert.strictEqual(result, 'foo');
       assert.ok(updateRecordStub.calledWithExactly(store, modelClass, snapshot));
     });
   });
@@ -87,8 +87,8 @@ module('Unit | Adapter | cloud firestore modular', function (hooks) {
 
       const userA = await getDoc(doc(db, 'users/user_a'));
 
-      assert.equal(userA.get('age'), 50);
-      assert.equal(userA.get('username'), 'user_a');
+      assert.strictEqual(userA.get('age'), 50);
+      assert.strictEqual(userA.get('username'), 'user_a');
     });
 
     test('should update record in a custom collection and resolve with the updated resource', async function (assert) {
@@ -315,7 +315,7 @@ module('Unit | Adapter | cloud firestore modular', function (hooks) {
         await adapter.findRecord(store, modelClass, modelId, snapshot);
       } catch (error) {
         // Assert
-        assert.equal(error.message, 'Record user_100 for model type user doesn\'t exist');
+        assert.strictEqual(error.message, 'Record user_100 for model type user doesn\'t exist');
       }
     });
   });
@@ -373,8 +373,8 @@ module('Unit | Adapter | cloud firestore modular', function (hooks) {
       const result = await adapter.findHasMany(store, snapshot, url, relationship);
 
       // Assert
-      assert.equal(result[0].id, 'post_a');
-      assert.equal(result[0].title, 'post_a');
+      assert.strictEqual(result[0].id, 'post_a');
+      assert.strictEqual(result[0].title, 'post_a');
       assert.ok(determineRelationshipTypeStub.calledWithExactly(relationship, store));
       assert.ok(inverseForStub.calledWithExactly(relationship.key, store));
     });
@@ -449,8 +449,8 @@ module('Unit | Adapter | cloud firestore modular', function (hooks) {
       const result = await adapter.findHasMany(store, snapshot, url, relationship);
 
       // Assert
-      assert.equal(result.length, 1);
-      assert.equal(result[0].id, 'post_a');
+      assert.strictEqual(result.length, 1);
+      assert.strictEqual(result[0].id, 'post_a');
       assert.ok(determineRelationshipTypeStub.calledWithExactly(relationship, store));
       assert.ok(inverseForStub.calledWithExactly(relationship.key, store));
     });
@@ -481,8 +481,8 @@ module('Unit | Adapter | cloud firestore modular', function (hooks) {
       const result = await adapter.findHasMany(store, snapshot, url, relationship);
 
       // Assert
-      assert.equal(result[0].id, 'post_b');
-      assert.equal(result[0].title, 'post_b');
+      assert.strictEqual(result[0].id, 'post_b');
+      assert.strictEqual(result[0].title, 'post_b');
     });
   });
 

--- a/tests/unit/adapters/cloud-firestore-test.ts
+++ b/tests/unit/adapters/cloud-firestore-test.ts
@@ -31,7 +31,7 @@ module('Unit | Adapter | cloud firestore', function (hooks) {
       const result = adapter.generateIdForRecord({}, 'foo');
 
       // Assert
-      assert.equal(typeof result, 'string');
+      assert.strictEqual(typeof result, 'string');
     });
   });
 
@@ -49,7 +49,7 @@ module('Unit | Adapter | cloud firestore', function (hooks) {
       const result = await adapter.createRecord(store, modelClass, snapshot);
 
       // Assert
-      assert.equal(result, 'foo');
+      assert.strictEqual(result, 'foo');
       assert.ok(updateRecordStub.calledWithExactly(store, modelClass, snapshot));
     });
   });
@@ -78,8 +78,8 @@ module('Unit | Adapter | cloud firestore', function (hooks) {
 
       const userA = await db.collection('users').doc('user_a').get();
 
-      assert.equal(userA.get('age'), 50);
-      assert.equal(userA.get('username'), 'user_a');
+      assert.strictEqual(userA.get('age'), 50);
+      assert.strictEqual(userA.get('username'), 'user_a');
     });
 
     test('should update record in a custom collection and resolve with the updated resource', async function (assert) {
@@ -306,7 +306,7 @@ module('Unit | Adapter | cloud firestore', function (hooks) {
         await adapter.findRecord(store, modelClass, modelId, snapshot);
       } catch (error) {
         // Assert
-        assert.equal(error.message, 'Record user_100 for model type user doesn\'t exist');
+        assert.strictEqual(error.message, 'Record user_100 for model type user doesn\'t exist');
       }
     });
   });
@@ -364,8 +364,8 @@ module('Unit | Adapter | cloud firestore', function (hooks) {
       const result = await adapter.findHasMany(store, snapshot, url, relationship);
 
       // Assert
-      assert.equal(result[0].id, 'post_a');
-      assert.equal(result[0].title, 'post_a');
+      assert.strictEqual(result[0].id, 'post_a');
+      assert.strictEqual(result[0].title, 'post_a');
       assert.ok(determineRelationshipTypeStub.calledWithExactly(relationship, store));
       assert.ok(inverseForStub.calledWithExactly(relationship.key, store));
     });
@@ -440,8 +440,8 @@ module('Unit | Adapter | cloud firestore', function (hooks) {
       const result = await adapter.findHasMany(store, snapshot, url, relationship);
 
       // Assert
-      assert.equal(result.length, 1);
-      assert.equal(result[0].id, 'post_a');
+      assert.strictEqual(result.length, 1);
+      assert.strictEqual(result[0].id, 'post_a');
       assert.ok(determineRelationshipTypeStub.calledWithExactly(relationship, store));
       assert.ok(inverseForStub.calledWithExactly(relationship.key, store));
     });
@@ -472,8 +472,8 @@ module('Unit | Adapter | cloud firestore', function (hooks) {
       const result = await adapter.findHasMany(store, snapshot, url, relationship);
 
       // Assert
-      assert.equal(result[0].id, 'post_b');
-      assert.equal(result[0].title, 'post_b');
+      assert.strictEqual(result[0].id, 'post_b');
+      assert.strictEqual(result[0].title, 'post_b');
     });
   });
 

--- a/tests/unit/authenticators/firebase-test.ts
+++ b/tests/unit/authenticators/firebase-test.ts
@@ -53,7 +53,7 @@ module('Unit | Authenticator | firebase', function (hooks) {
       await authenticator.invalidate();
 
       // Assert
-      assert.equal(auth.currentUser, null);
+      assert.strictEqual(auth.currentUser, null);
     });
   });
 


### PR DESCRIPTION
- Convert QUnit `equal` invocations to `strictEqual` (required in Ember 4's QUnit version)
- Cast numbers to strings in two tests