### PR TITLE
Fix useEmulator called twice

### DIFF
--- a/addon/instance-initializers/firebase-settings.ts
+++ b/addon/instance-initializers/firebase-settings.ts
@@ -28,7 +28,9 @@ function setupFirestore(app: firebase.app.App, config: FirestoreAddonConfig) {
   if (config.emulator) {
     const { hostname, port, options } = config.emulator;
 
-    db.useEmulator(hostname, port, options);
+    if ((db as any)._delegate._settings.host === 'firestore.googleapis.com') {
+      db.useEmulator(hostname, port, options);
+    }
   }
 }
 


### PR DESCRIPTION
- Quick and dirty fix for the `Host has been set in both settings() and useEmulator(), emulator host will be used` warning we see in tests.
- Uses private APIs unfortunately. Not sure if there is a way to get around this.
- Solution pulled from this package: https://github.com/nuxt-community/firebase-module/blob/master/lib/plugins/services/firestore.js
- https://github.com/nuxt-community/firebase-module/issues/390

I don't necessarily want to merge this PR in its current state, but I'm curious what we think about this fix.