### PR TITLE
Fix cache bug

### DIFF
--- a/addon/adapters/cloud-firestore-modular.ts
+++ b/addon/adapters/cloud-firestore-modular.ts
@@ -22,6 +22,8 @@ import firebase from 'firebase/compat/app';
 import {
   collection,
   doc,
+  getDoc,
+  getDocs,
   query,
   where,
   writeBatch,
@@ -157,7 +159,7 @@ export default class CloudFirestoreModularAdapter extends Adapter {
         const docRef = doc(colRef, id);
         const docSnapshot = snapshot.adapterOptions?.isRealtime && !this.isFastBoot
           ? await this.firestoreDataManager.findRecordRealtime(type.modelName, docRef)
-          : await this.firestoreDataManager.findRecord(docRef);
+          : await getDoc(docRef);
 
         if (docSnapshot.exists()) {
           resolve(flattenDocSnapshot(docSnapshot));
@@ -182,7 +184,7 @@ export default class CloudFirestoreModularAdapter extends Adapter {
         const colRef = collection(db, buildCollectionName(type.modelName));
         const querySnapshot = snapshotRecordArray?.adapterOptions?.isRealtime && !this.isFastBoot
           ? await this.firestoreDataManager.findAllRealtime(type.modelName, colRef)
-          : await this.firestoreDataManager.findAll(colRef);
+          : await getDocs(colRef);
 
         const result = querySnapshot.docs.map((docSnapshot) => flattenDocSnapshot(docSnapshot));
 
@@ -212,7 +214,7 @@ export default class CloudFirestoreModularAdapter extends Adapter {
         };
         const docSnapshots = queryOption.isRealtime && !this.isFastBoot
           ? await this.firestoreDataManager.queryRealtime(config)
-          : await this.firestoreDataManager.query(config);
+          : await this.firestoreDataManager.queryWithReferenceTo(queryRef, this.referenceKeyName);
 
         const result = docSnapshots.map((docSnapshot) => (flattenDocSnapshot(docSnapshot)));
 
@@ -241,7 +243,7 @@ export default class CloudFirestoreModularAdapter extends Adapter {
         const modelName = relationship.type;
         const docSnapshot = relationship.options.isRealtime && !this.isFastBoot
           ? await this.firestoreDataManager.findRecordRealtime(modelName, docRef)
-          : await this.firestoreDataManager.findRecord(docRef);
+          : await getDoc(docRef);
 
         if (docSnapshot.exists()) {
           resolve(flattenDocSnapshot(docSnapshot));
@@ -272,7 +274,7 @@ export default class CloudFirestoreModularAdapter extends Adapter {
         };
         const documentSnapshots = relationship.options.isRealtime && !this.isFastBoot
           ? await this.firestoreDataManager.findHasManyRealtime(config)
-          : await this.firestoreDataManager.query(config);
+          : await this.firestoreDataManager.queryWithReferenceTo(queryRef, this.referenceKeyName);
 
         const result = documentSnapshots.map((docSnapshot) => (flattenDocSnapshot(docSnapshot)));
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint:hbs:fix": "ember-template-lint . --fix",
     "lint:js": "eslint . --cache",
     "lint:js:fix": "eslint . --fix",
-    "start": "npm run build:wrappers && firebase emulators:exec --import=./emulator-data --project ember-cloud-firestore-adapter-test-project \"ember serve\"",
+    "start": "npm run build:wrappers && firebase emulators:exec --import=./emulator-data --project ember-cloud-firestore-adapter-test-project --ui \"ember serve\"",
     "test": "npm-run-all lint test:*",
     "test:ember": "npm run build:wrappers && firebase emulators:exec --import=./emulator-data --project ember-cloud-firestore-adapter-test-project \"ember test\"",
     "test:ember-compatibility": "npm run build:wrappers && firebase emulators:exec --import=./emulator-data --project ember-cloud-firestore-adapter-test-project \"ember try:each\"",

--- a/tests/dummy/app/routes/find-record.ts
+++ b/tests/dummy/app/routes/find-record.ts
@@ -9,6 +9,10 @@ export default class FindRecordRoute extends Route {
   public declare store: Store;
 
   public async model(): Promise<GroupModel> {
-    return this.store.findRecord('group', 'group_a');
+    return this.store.findRecord('group', 'group_a', {
+      adapterOptions: {
+        isRealtime: true,
+      },
+    });
   }
 }

--- a/tests/dummy/app/routes/query.ts
+++ b/tests/dummy/app/routes/query.ts
@@ -6,9 +6,9 @@ import Store from '@ember-data/store';
 import { CollectionReference } from 'firebase/firestore';
 
 import {
+  limit,
   query,
   orderBy,
-  limit,
 } from 'ember-cloud-firestore-adapter/firebase/firestore';
 
 import GroupModel from '../models/group';
@@ -19,6 +19,7 @@ export default class QueryRoute extends Route {
 
   public async model(): Promise<ArrayProxy<GroupModel>> {
     return this.store.query('group', {
+      isRealtime: true,
       filter(reference: CollectionReference) {
         return query(reference, orderBy('name'), limit(1));
       },

--- a/tests/unit/services/-firestore-data-manager-test.ts
+++ b/tests/unit/services/-firestore-data-manager-test.ts
@@ -30,23 +30,6 @@ module('Unit | Service | -firestore-data-manager', function (hooks) {
     await resetFixtureData(db);
   });
 
-  module('findRecord()', function () {
-    test('should return fetched record', async function (assert) {
-      // Arrange
-      const docRef = doc(db, 'users', 'user_a');
-      const firestoreDataManager = this.owner.lookup(
-        'service:-firestore-data-manager',
-      ) as FirestoreDataManager;
-
-      // Act
-      const result = await firestoreDataManager.findRecord(docRef);
-
-      // Assert
-      assert.equal(result.id, 'user_a');
-      assert.deepEqual(result.data(), { name: 'user_a', age: 15, username: 'user_a' });
-    });
-  });
-
   module('findRecordRealtime()', function () {
     test('should return fetched record', async function (assert) {
       // Arrange
@@ -101,24 +84,6 @@ module('Unit | Service | -firestore-data-manager', function (hooks) {
       // Assert
       await waitUntil(() => unloadRecordSpy.called);
       assert.ok(true);
-    });
-  });
-
-  module('findAll()', function () {
-    test('should return fetched records', async function (assert) {
-      // Arrange
-      const colRef = collection(db, 'users');
-      const firestoreDataManager = this.owner.lookup(
-        'service:-firestore-data-manager',
-      ) as FirestoreDataManager;
-
-      // Act
-      const result = await firestoreDataManager.findAll(colRef);
-
-      // Assert
-      assert.equal(result.size, 3);
-      assert.equal(result.docs[0].id, 'user_a');
-      assert.deepEqual(result.docs[0].data(), { name: 'user_a', age: 15, username: 'user_a' });
     });
   });
 
@@ -179,54 +144,6 @@ module('Unit | Service | -firestore-data-manager', function (hooks) {
       // Assert
       await waitUntil(() => unloadRecordSpy.calledOnce);
       assert.ok(true);
-    });
-  });
-
-  module('query()', function () {
-    test('should return fetched records', async function (assert) {
-      // Arrange
-      const colRef = collection(db, 'users');
-      const queryRef = query(colRef);
-      const config = {
-        queryRef,
-        modelName: 'user',
-        referenceKeyName: 'referenceTo',
-        recordArray: {} as DS.AdapterPopulatedRecordArray<unknown>,
-      };
-      const firestoreDataManager = this.owner.lookup(
-        'service:-firestore-data-manager',
-      ) as FirestoreDataManager;
-
-      // Act
-      const result = await firestoreDataManager.query(config);
-
-      // Assert
-      assert.equal(result.length, 3);
-      assert.equal(result[0].id, 'user_a');
-      assert.deepEqual(result[0].data(), { name: 'user_a', age: 15, username: 'user_a' });
-    });
-
-    test('should return fetched records with referenceTo indicators', async function (assert) {
-      // Arrange
-      const colRef = collection(db, 'users/user_a/groups');
-      const queryRef = query(colRef);
-      const config = {
-        queryRef,
-        modelName: 'group',
-        referenceKeyName: 'referenceTo',
-        recordArray: {} as DS.AdapterPopulatedRecordArray<unknown>,
-      };
-      const firestoreDataManager = this.owner.lookup(
-        'service:-firestore-data-manager',
-      ) as FirestoreDataManager;
-
-      // Act
-      const result = await firestoreDataManager.query(config);
-
-      // Assert
-      assert.equal(result.length, 1);
-      assert.equal(result[0].id, 'group_a');
-      assert.deepEqual(result[0].data(), { name: 'group_a' });
     });
   });
 
@@ -394,6 +311,44 @@ module('Unit | Service | -firestore-data-manager', function (hooks) {
       // Assert
       await waitUntil(() => reloadStub.calledOnce);
       assert.ok(true);
+    });
+  });
+
+  module('queryWithReferenceTo()', function () {
+    test('should return fetched records', async function (assert) {
+      // Arrange
+      const colRef = collection(db, 'users');
+      const queryRef = query(colRef);
+      const referenceKeyName = 'referenceTo';
+      const firestoreDataManager = this.owner.lookup(
+        'service:-firestore-data-manager',
+      ) as FirestoreDataManager;
+
+      // Act
+      const result = await firestoreDataManager.queryWithReferenceTo(queryRef, referenceKeyName);
+
+      // Assert
+      assert.equal(result.length, 3);
+      assert.equal(result[0].id, 'user_a');
+      assert.deepEqual(result[0].data(), { name: 'user_a', age: 15, username: 'user_a' });
+    });
+
+    test('should return fetched records with referenceTo indicators', async function (assert) {
+      // Arrange
+      const colRef = collection(db, 'users/user_a/groups');
+      const queryRef = query(colRef);
+      const referenceKeyName = 'referenceTo';
+      const firestoreDataManager = this.owner.lookup(
+        'service:-firestore-data-manager',
+      ) as FirestoreDataManager;
+
+      // Act
+      const result = await firestoreDataManager.queryWithReferenceTo(queryRef, referenceKeyName);
+
+      // Assert
+      assert.equal(result.length, 1);
+      assert.equal(result[0].id, 'group_a');
+      assert.deepEqual(result[0].data(), { name: 'group_a' });
     });
   });
 });


### PR DESCRIPTION
Recent discoveries from #242 specifically in this [comment](https://github.com/mikkopaderes/ember-cloud-firestore-adapter/issues/242#issuecomment-1061535783) has shown that there's a cache bug in the addon.

e.g.

```javascript
store.findRecord('user', 'user_a', {
  adapterOptions: { isRealtime: true },
});

// Somewhere down the line
store.findAll('user');
```

What will happen here is `store.findAll` won't return all user data because `isRealtime` isn't set to `true`. Behind the scenes, this still do a `onSnapshot` that quickly unsubscribes because we want to utilize the caching mechanism of Firestore. Unfortunately, because we unsubscribe immediately, we only really return the cached data which is what was returned from the previous `store.findRecord`. This is also an issue with `hasMany` and `query`.

Not to mention, how we query data violates the best practice of [reduce snapshot listener churn rate](https://firebase.google.com/docs/firestore/best-practices#realtime_updates).

This PR introduces the following changes:
- Non-realtime fetches will no longer fetch from cache
- Redo all logic that violates the listener churn rate

Note that this doesn't fix the initial issue in #242 but merely fixes a side bug.