### PR TITLE
Expose snapshot record to belongsTo buildReference

### DIFF
--- a/addon/serializers/cloud-firestore-modular.ts
+++ b/addon/serializers/cloud-firestore-modular.ts
@@ -29,7 +29,7 @@ interface RelationshipDefinition {
   key: string;
   type: string;
   options: {
-    buildReference?(db: Firestore): CollectionReference
+    buildReference?(db: Firestore, record: unknown): CollectionReference
   };
 }
 
@@ -102,7 +102,10 @@ export default class CloudFirestoreSerializer extends JSONSerializer {
       const docId = json[relationship.key] as string;
 
       if (relationship.options.buildReference) {
-        json[relationship.key] = doc(relationship.options.buildReference(db), docId);
+        json[relationship.key] = doc(
+          relationship.options.buildReference(db, snapshot.record),
+          docId,
+        );
       } else {
         const collectionName = buildCollectionName(relationship.type);
         const path = `${collectionName}/${docId}`;

--- a/docs/relationships.md
+++ b/docs/relationships.md
@@ -32,6 +32,7 @@ Hook for providing a custom collection reference.
 | Name   | Type                                                                                                         | Description       |
 | -------| ------------------------------------------------------------------------------------------------------------ | ----------------- |
 | db     | [`Firestore`](https://firebase.google.com/docs/reference/js/firestore_.firestore) |                   |
+| record | Object | The record itself |
 
 ## `hasMany`
 
@@ -75,6 +76,7 @@ Hook for providing a custom collection reference.
 | Name   | Type                                                                                                         | Description       |
 | -------| ------------------------------------------------------------------------------------------------------------ | ----------------- |
 | db     | [`Firestore`](https://firebase.google.com/docs/reference/js/firestore_.firestore) |                   |
+| record | Object | The record itself |
 
 ### `filter`
 


### PR DESCRIPTION
**Changes:**

- Expose snapshot record to `buildReference` of a `belongsTo` relationship
- Fix doc not indicating that snapshot record is exposed for `buildReference` of a `hasMany` relationship