### PR TITLE
Bump `@ember/test-helpers`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       },
       "devDependencies": {
         "@ember/optional-features": "^2.0.0",
-        "@ember/test-helpers": "~2.7.0",
+        "@ember/test-helpers": "^2.9.0",
         "@embroider/test-setup": "^1.6.0",
         "@glimmer/component": "^1.1.2",
         "@glimmer/tracking": "^1.1.2",
@@ -36,7 +36,6 @@
         "@types/ember__string": "^3.16.3",
         "@types/ember__template": "^3.16.1",
         "@types/ember__test": "^3.16.1",
-        "@types/ember__test-helpers": "^2.0.2",
         "@types/ember__utils": "^3.16.2",
         "@types/ember-data": "^3.16.15",
         "@types/ember-data__adapter": "^3.16.1",
@@ -2823,223 +2822,52 @@
       }
     },
     "node_modules/@ember/test-helpers": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@ember/test-helpers/-/test-helpers-2.7.0.tgz",
-      "integrity": "sha512-eWFtw5+sbci1Fw+E+HoyaMxY126LvK7jul6i8tad48zlWoxrOalbhJhz1mKqIo4daHbqIZWuFgQhOib4QfTKCQ==",
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@ember/test-helpers/-/test-helpers-2.9.4.tgz",
+      "integrity": "sha512-z+Qs1NYWyIVDmrY6WdmOS5mdG1lJ5CFfzh6dRhLfs9lq45deDaDrVNcaCYhnNeJZTvUBK2XR2SvPcZm0RloXdA==",
       "dev": true,
       "dependencies": {
         "@ember/test-waiters": "^3.0.0",
+        "@embroider/macros": "^1.10.0",
+        "@embroider/util": "^1.9.0",
         "broccoli-debug": "^0.6.5",
         "broccoli-funnel": "^3.0.8",
-        "ember-cli-babel": "^7.26.6",
-        "ember-cli-htmlbars": "^5.7.1",
+        "ember-cli-babel": "^7.26.11",
+        "ember-cli-htmlbars": "^6.1.1",
         "ember-destroyable-polyfill": "^2.0.3"
       },
       "engines": {
         "node": "10.* || 12.* || 14.* || 15.* || >= 16.*"
+      },
+      "peerDependencies": {
+        "ember-source": ">=3.8.0"
       }
     },
-    "node_modules/@ember/test-helpers/node_modules/async-disk-cache": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-2.1.0.tgz",
-      "integrity": "sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==",
+    "node_modules/@ember/test-helpers/node_modules/@embroider/util": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@embroider/util/-/util-1.12.0.tgz",
+      "integrity": "sha512-P4M1QADEH9ceIYC9mwHeV+6DDgEIQQYFfZi728nVKqTAxakXoiLgu/BCyQmEGyow9fYEPYaC1boDCZxW2JQAXg==",
       "dev": true,
       "dependencies": {
-        "debug": "^4.1.1",
-        "heimdalljs": "^0.2.3",
-        "istextorbinary": "^2.5.1",
-        "mkdirp": "^0.5.0",
-        "rimraf": "^3.0.0",
-        "rsvp": "^4.8.5",
-        "username-sync": "^1.0.2"
+        "@embroider/macros": "^1.13.0",
+        "broccoli-funnel": "^3.0.5",
+        "ember-cli-babel": "^7.26.11"
       },
       "engines": {
-        "node": "8.* || >= 10.*"
-      }
-    },
-    "node_modules/@ember/test-helpers/node_modules/broccoli-persistent-filter": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.2.tgz",
-      "integrity": "sha512-CbU95RXXVyy+eJV9XTiHUC7NnsY3EvdVrGzp3YgyvO2bzXZFE5/GzDp4X/VQqX+jsk4qyT1HvMOF0sD1DX68TQ==",
-      "dev": true,
-      "dependencies": {
-        "async-disk-cache": "^2.0.0",
-        "async-promise-queue": "^1.0.3",
-        "broccoli-plugin": "^4.0.3",
-        "fs-tree-diff": "^2.0.0",
-        "hash-for-dep": "^1.5.0",
-        "heimdalljs": "^0.2.1",
-        "heimdalljs-logger": "^0.1.7",
-        "promise-map-series": "^0.2.1",
-        "rimraf": "^3.0.0",
-        "symlink-or-copy": "^1.0.1",
-        "sync-disk-cache": "^2.0.0"
+        "node": "14.* || >= 16"
       },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/@ember/test-helpers/node_modules/broccoli-plugin": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
-      "integrity": "sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==",
-      "dev": true,
-      "dependencies": {
-        "broccoli-node-api": "^1.7.0",
-        "broccoli-output-wrapper": "^3.2.5",
-        "fs-merger": "^3.2.1",
-        "promise-map-series": "^0.3.0",
-        "quick-temp": "^0.1.8",
-        "rimraf": "^3.0.2",
-        "symlink-or-copy": "^1.3.1"
+      "peerDependencies": {
+        "@glint/environment-ember-loose": "^1.0.0",
+        "@glint/template": "^1.0.0",
+        "ember-source": "*"
       },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/@ember/test-helpers/node_modules/broccoli-plugin/node_modules/promise-map-series": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.3.0.tgz",
-      "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==",
-      "dev": true,
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/@ember/test-helpers/node_modules/editions": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz",
-      "integrity": "sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==",
-      "dev": true,
-      "dependencies": {
-        "errlop": "^2.0.0",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=0.8"
-      },
-      "funding": {
-        "url": "https://bevry.me/fund"
-      }
-    },
-    "node_modules/@ember/test-helpers/node_modules/editions/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@ember/test-helpers/node_modules/ember-cli-htmlbars": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.2.tgz",
-      "integrity": "sha512-Uj6R+3TtBV5RZoJY14oZn/sNPnc+UgmC8nb5rI4P3fR/gYoyTFIZSXiIM7zl++IpMoIrocxOrgt+mhonKphgGg==",
-      "dev": true,
-      "dependencies": {
-        "@ember/edition-utils": "^1.2.0",
-        "babel-plugin-htmlbars-inline-precompile": "^5.0.0",
-        "broccoli-debug": "^0.6.5",
-        "broccoli-persistent-filter": "^3.1.2",
-        "broccoli-plugin": "^4.0.3",
-        "common-tags": "^1.8.0",
-        "ember-cli-babel-plugin-helpers": "^1.1.1",
-        "ember-cli-version-checker": "^5.1.2",
-        "fs-tree-diff": "^2.0.1",
-        "hash-for-dep": "^1.5.1",
-        "heimdalljs-logger": "^0.1.10",
-        "json-stable-stringify": "^1.0.1",
-        "semver": "^7.3.4",
-        "silent-error": "^1.1.1",
-        "strip-bom": "^4.0.0",
-        "walk-sync": "^2.2.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/@ember/test-helpers/node_modules/fs-tree-diff": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
-      "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
-      "dev": true,
-      "dependencies": {
-        "@types/symlink-or-copy": "^1.2.0",
-        "heimdalljs-logger": "^0.1.7",
-        "object-assign": "^4.1.0",
-        "path-posix": "^1.0.0",
-        "symlink-or-copy": "^1.1.8"
-      },
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/@ember/test-helpers/node_modules/istextorbinary": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz",
-      "integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
-      "dev": true,
-      "dependencies": {
-        "binaryextensions": "^2.1.2",
-        "editions": "^2.2.0",
-        "textextensions": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://bevry.me/fund"
-      }
-    },
-    "node_modules/@ember/test-helpers/node_modules/minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true
-    },
-    "node_modules/@ember/test-helpers/node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/@ember/test-helpers/node_modules/rsvp": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-      "dev": true,
-      "engines": {
-        "node": "6.* || >= 7.*"
-      }
-    },
-    "node_modules/@ember/test-helpers/node_modules/strip-bom": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@ember/test-helpers/node_modules/walk-sync": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-      "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-      "dev": true,
-      "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "ensure-posix-path": "^1.1.0",
-        "matcher-collection": "^2.0.0",
-        "minimatch": "^3.0.4"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
+      "peerDependenciesMeta": {
+        "@glint/environment-ember-loose": {
+          "optional": true
+        },
+        "@glint/template": {
+          "optional": true
+        }
       }
     },
     "node_modules/@ember/test-waiters": {
@@ -3058,13 +2886,13 @@
       }
     },
     "node_modules/@embroider/macros": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-1.8.3.tgz",
-      "integrity": "sha512-gnIOfTL/pUkoD6oI7JyWOqXlVIUgZM+CnbH10/YNtZr2K0hij9eZQMdgjOZZVgN0rKOFw9dIREqc1ygrJHRYQA==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-1.13.1.tgz",
+      "integrity": "sha512-4htraP/rNIht8uCxXoc59Bw2EsBFfc4YUQD9XSpzJ4xUr1V0GQf9wL/noeSuYSxIhwRfZOErnJhsdyf1hH+I/A==",
       "dependencies": {
-        "@embroider/shared-internals": "1.8.3",
+        "@embroider/shared-internals": "2.4.0",
         "assert-never": "^1.2.1",
-        "babel-import-util": "^1.1.0",
+        "babel-import-util": "^2.0.0",
         "ember-cli-babel": "^7.26.6",
         "find-up": "^5.0.0",
         "lodash": "^4.17.21",
@@ -3073,6 +2901,41 @@
       },
       "engines": {
         "node": "12.* || 14.* || >= 16"
+      },
+      "peerDependencies": {
+        "@glint/template": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@glint/template": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@embroider/macros/node_modules/@embroider/shared-internals": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-2.4.0.tgz",
+      "integrity": "sha512-pFE05ebenWMC9XAPRjadYCXXb6VmqjkhYN5uqkhPo+VUmMHnx7sZYYxqGjxfVuhC/ghS/BNlOffOCXDOoE7k7g==",
+      "dependencies": {
+        "babel-import-util": "^2.0.0",
+        "debug": "^4.3.2",
+        "ember-rfc176-data": "^0.3.17",
+        "fs-extra": "^9.1.0",
+        "js-string-escape": "^1.0.1",
+        "lodash": "^4.17.21",
+        "resolve-package-path": "^4.0.1",
+        "semver": "^7.3.5",
+        "typescript-memoize": "^1.0.1"
+      },
+      "engines": {
+        "node": "12.* || 14.* || >= 16"
+      }
+    },
+    "node_modules/@embroider/macros/node_modules/babel-import-util": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/babel-import-util/-/babel-import-util-2.0.0.tgz",
+      "integrity": "sha512-pkWynbLwru0RZmA9iKeQL63+CkkW0RCP3kL5njCtudd6YPUKb5Pa0kL4fb3bmuKn2QDBFwY5mvvhEK/+jv2Ynw==",
+      "engines": {
+        "node": ">= 12.*"
       }
     },
     "node_modules/@embroider/shared-internals": {
@@ -3902,8 +3765,7 @@
     "node_modules/@glimmer/env": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/@glimmer/env/-/env-0.1.7.tgz",
-      "integrity": "sha512-JKF/a9I9jw6fGoz8kA7LEQslrwJ5jms5CXhu/aqkBWk+PmZ6pTl8mlb/eJ/5ujBGTiQzBhy5AIWF712iA+4/mw==",
-      "dev": true
+      "integrity": "sha512-JKF/a9I9jw6fGoz8kA7LEQslrwJ5jms5CXhu/aqkBWk+PmZ6pTl8mlb/eJ/5ujBGTiQzBhy5AIWF712iA+4/mw=="
     },
     "node_modules/@glimmer/global-context": {
       "version": "0.83.1",
@@ -4149,8 +4011,7 @@
     "node_modules/@handlebars/parser": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@handlebars/parser/-/parser-2.0.0.tgz",
-      "integrity": "sha512-EP9uEDZv/L5Qh9IWuMUGJRfwhXJ4h1dqKTT4/3+tY0eu7sPis7xh23j61SYUnNF4vqCQvvUXpDo9Bh/+q1zASA==",
-      "dev": true
+      "integrity": "sha512-EP9uEDZv/L5Qh9IWuMUGJRfwhXJ4h1dqKTT4/3+tY0eu7sPis7xh23j61SYUnNF4vqCQvvUXpDo9Bh/+q1zASA=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.5.0",
@@ -4353,8 +4214,7 @@
     "node_modules/@simple-dom/interface": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@simple-dom/interface/-/interface-1.4.0.tgz",
-      "integrity": "sha512-l5qumKFWU0S+4ZzMaLXFU8tQZsicHEMEyAxI5kDFGhJsRqDwe0a7/iPA/GdxlGyDKseQQAgIz5kzU7eXTrlSpA==",
-      "dev": true
+      "integrity": "sha512-l5qumKFWU0S+4ZzMaLXFU8tQZsicHEMEyAxI5kDFGhJsRqDwe0a7/iPA/GdxlGyDKseQQAgIz5kzU7eXTrlSpA=="
     },
     "node_modules/@simple-dom/parser": {
       "version": "1.4.0",
@@ -4708,19 +4568,6 @@
       "dev": true,
       "dependencies": {
         "@types/ember__application": "^3"
-      }
-    },
-    "node_modules/@types/ember__test-helpers": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@types/ember__test-helpers/-/ember__test-helpers-2.8.0.tgz",
-      "integrity": "sha512-lAnpTPmGNuocrJiIxFP6pkMWhEeTmrqsa4yBKjaBBxDXWF1qh3CCWEr/Tj7oe7HVUyL7w53mxyPIjskvCyiEBw==",
-      "dev": true,
-      "dependencies": {
-        "@types/ember__application": "*",
-        "@types/ember__error": "*",
-        "@types/ember__test-helpers": "*",
-        "@types/ember-resolver": "*",
-        "@types/htmlbars-inline-precompile": "*"
       }
     },
     "node_modules/@types/ember__utils": {
@@ -6438,28 +6285,52 @@
       }
     },
     "node_modules/babel-plugin-ember-template-compilation": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-ember-template-compilation/-/babel-plugin-ember-template-compilation-1.0.2.tgz",
-      "integrity": "sha512-4HBMksmlYsWEf/C/n3uW5rkBRbUp4FNaspzdQTAHgLbfCJnkLze8R6i6sUSge48y/Wne7mx+vcImI1o6rlUwXQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-ember-template-compilation/-/babel-plugin-ember-template-compilation-2.2.0.tgz",
+      "integrity": "sha512-1I7f5gf06h5wKdKUvaYEIaoSFur5RLUvTMQG4ak0c5Y11DWUxcoX9hrun1xe9fqfY2dtGFK+ZUM6sn6z8sqK/w==",
       "dependencies": {
-        "babel-import-util": "^1.2.0",
-        "line-column": "^1.0.2",
-        "magic-string": "^0.26.0",
-        "string.prototype.matchall": "^4.0.5"
+        "@glimmer/syntax": "^0.84.3",
+        "babel-import-util": "^2.0.0"
       },
       "engines": {
         "node": ">= 12.*"
       }
     },
-    "node_modules/babel-plugin-ember-template-compilation/node_modules/magic-string": {
-      "version": "0.26.2",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.2.tgz",
-      "integrity": "sha512-NzzlXpclt5zAbmo6h6jNc8zl2gNRGHvmsZW4IvZhTC4W7k4OlLP+S5YLussa/r3ixNT66KOQfNORlXHSOy/X4A==",
+    "node_modules/babel-plugin-ember-template-compilation/node_modules/@glimmer/interfaces": {
+      "version": "0.84.3",
+      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.84.3.tgz",
+      "integrity": "sha512-dk32ykoNojt0mvEaIW6Vli5MGTbQo58uy3Epj7ahCgTHmWOKuw/0G83f2UmFprRwFx689YTXG38I/vbpltEjzg==",
       "dependencies": {
-        "sourcemap-codec": "^1.4.8"
-      },
+        "@simple-dom/interface": "^1.4.0"
+      }
+    },
+    "node_modules/babel-plugin-ember-template-compilation/node_modules/@glimmer/syntax": {
+      "version": "0.84.3",
+      "resolved": "https://registry.npmjs.org/@glimmer/syntax/-/syntax-0.84.3.tgz",
+      "integrity": "sha512-ioVbTic6ZisLxqTgRBL2PCjYZTFIwobifCustrozRU2xGDiYvVIL0vt25h2c1ioDsX59UgVlDkIK4YTAQQSd2A==",
+      "dependencies": {
+        "@glimmer/interfaces": "0.84.3",
+        "@glimmer/util": "0.84.3",
+        "@handlebars/parser": "~2.0.0",
+        "simple-html-tokenizer": "^0.5.11"
+      }
+    },
+    "node_modules/babel-plugin-ember-template-compilation/node_modules/@glimmer/util": {
+      "version": "0.84.3",
+      "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.84.3.tgz",
+      "integrity": "sha512-qFkh6s16ZSRuu2rfz3T4Wp0fylFj3HBsONGXQcrAdZjdUaIS6v3pNj6mecJ71qRgcym9Hbaq/7/fefIwECUiKw==",
+      "dependencies": {
+        "@glimmer/env": "0.1.7",
+        "@glimmer/interfaces": "0.84.3",
+        "@simple-dom/interface": "^1.4.0"
+      }
+    },
+    "node_modules/babel-plugin-ember-template-compilation/node_modules/babel-import-util": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/babel-import-util/-/babel-import-util-2.0.0.tgz",
+      "integrity": "sha512-pkWynbLwru0RZmA9iKeQL63+CkkW0RCP3kL5njCtudd6YPUKb5Pa0kL4fb3bmuKn2QDBFwY5mvvhEK/+jv2Ynw==",
       "engines": {
-        "node": ">=12"
+        "node": ">= 12.*"
       }
     },
     "node_modules/babel-plugin-filter-imports": {
@@ -12067,12 +11938,12 @@
       "dev": true
     },
     "node_modules/ember-cli-htmlbars": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-6.1.0.tgz",
-      "integrity": "sha512-kT+MA2JsNLk10HpxAjpB5HHtR0WCoxZEUwLsy/BBww5lXmsrf34QzmTw7SL6DabZVxs+YCb9RhU9KTmFygGxCg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-6.3.0.tgz",
+      "integrity": "sha512-N9Y80oZfcfWLsqickMfRd9YByVcTGyhYRnYQ2XVPVrp6jyUyOeRWmEAPh7ERSXpp8Ws4hr/JB9QVQrn/yZa+Ag==",
       "dependencies": {
         "@ember/edition-utils": "^1.2.0",
-        "babel-plugin-ember-template-compilation": "^1.0.0",
+        "babel-plugin-ember-template-compilation": "^2.0.0",
         "babel-plugin-htmlbars-inline-precompile": "^5.3.0",
         "broccoli-debug": "^0.6.5",
         "broccoli-persistent-filter": "^3.1.2",
@@ -38705,8 +38576,7 @@
     "node_modules/simple-html-tokenizer": {
       "version": "0.5.11",
       "resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.5.11.tgz",
-      "integrity": "sha512-C2WEK/Z3HoSFbYq8tI7ni3eOo/NneSPRoPpcM7WdLjFOArFuyXEjAoCdOC3DgMfRyziZQ1hCNR4mrNdWEvD0og==",
-      "dev": true
+      "integrity": "sha512-C2WEK/Z3HoSFbYq8tI7ni3eOo/NneSPRoPpcM7WdLjFOArFuyXEjAoCdOC3DgMfRyziZQ1hCNR4mrNdWEvD0og=="
     },
     "node_modules/sinon": {
       "version": "9.2.4",
@@ -43959,179 +43829,30 @@
       }
     },
     "@ember/test-helpers": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@ember/test-helpers/-/test-helpers-2.7.0.tgz",
-      "integrity": "sha512-eWFtw5+sbci1Fw+E+HoyaMxY126LvK7jul6i8tad48zlWoxrOalbhJhz1mKqIo4daHbqIZWuFgQhOib4QfTKCQ==",
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@ember/test-helpers/-/test-helpers-2.9.4.tgz",
+      "integrity": "sha512-z+Qs1NYWyIVDmrY6WdmOS5mdG1lJ5CFfzh6dRhLfs9lq45deDaDrVNcaCYhnNeJZTvUBK2XR2SvPcZm0RloXdA==",
       "dev": true,
       "requires": {
         "@ember/test-waiters": "^3.0.0",
+        "@embroider/macros": "^1.10.0",
+        "@embroider/util": "^1.9.0",
         "broccoli-debug": "^0.6.5",
         "broccoli-funnel": "^3.0.8",
-        "ember-cli-babel": "^7.26.6",
-        "ember-cli-htmlbars": "^5.7.1",
+        "ember-cli-babel": "^7.26.11",
+        "ember-cli-htmlbars": "^6.1.1",
         "ember-destroyable-polyfill": "^2.0.3"
       },
       "dependencies": {
-        "async-disk-cache": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-2.1.0.tgz",
-          "integrity": "sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==",
+        "@embroider/util": {
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/@embroider/util/-/util-1.12.0.tgz",
+          "integrity": "sha512-P4M1QADEH9ceIYC9mwHeV+6DDgEIQQYFfZi728nVKqTAxakXoiLgu/BCyQmEGyow9fYEPYaC1boDCZxW2JQAXg==",
           "dev": true,
           "requires": {
-            "debug": "^4.1.1",
-            "heimdalljs": "^0.2.3",
-            "istextorbinary": "^2.5.1",
-            "mkdirp": "^0.5.0",
-            "rimraf": "^3.0.0",
-            "rsvp": "^4.8.5",
-            "username-sync": "^1.0.2"
-          }
-        },
-        "broccoli-persistent-filter": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.2.tgz",
-          "integrity": "sha512-CbU95RXXVyy+eJV9XTiHUC7NnsY3EvdVrGzp3YgyvO2bzXZFE5/GzDp4X/VQqX+jsk4qyT1HvMOF0sD1DX68TQ==",
-          "dev": true,
-          "requires": {
-            "async-disk-cache": "^2.0.0",
-            "async-promise-queue": "^1.0.3",
-            "broccoli-plugin": "^4.0.3",
-            "fs-tree-diff": "^2.0.0",
-            "hash-for-dep": "^1.5.0",
-            "heimdalljs": "^0.2.1",
-            "heimdalljs-logger": "^0.1.7",
-            "promise-map-series": "^0.2.1",
-            "rimraf": "^3.0.0",
-            "symlink-or-copy": "^1.0.1",
-            "sync-disk-cache": "^2.0.0"
-          }
-        },
-        "broccoli-plugin": {
-          "version": "4.0.7",
-          "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
-          "integrity": "sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==",
-          "dev": true,
-          "requires": {
-            "broccoli-node-api": "^1.7.0",
-            "broccoli-output-wrapper": "^3.2.5",
-            "fs-merger": "^3.2.1",
-            "promise-map-series": "^0.3.0",
-            "quick-temp": "^0.1.8",
-            "rimraf": "^3.0.2",
-            "symlink-or-copy": "^1.3.1"
-          },
-          "dependencies": {
-            "promise-map-series": {
-              "version": "0.3.0",
-              "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.3.0.tgz",
-              "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==",
-              "dev": true
-            }
-          }
-        },
-        "editions": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz",
-          "integrity": "sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==",
-          "dev": true,
-          "requires": {
-            "errlop": "^2.0.0",
-            "semver": "^6.3.0"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "6.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-              "dev": true
-            }
-          }
-        },
-        "ember-cli-htmlbars": {
-          "version": "5.7.2",
-          "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.2.tgz",
-          "integrity": "sha512-Uj6R+3TtBV5RZoJY14oZn/sNPnc+UgmC8nb5rI4P3fR/gYoyTFIZSXiIM7zl++IpMoIrocxOrgt+mhonKphgGg==",
-          "dev": true,
-          "requires": {
-            "@ember/edition-utils": "^1.2.0",
-            "babel-plugin-htmlbars-inline-precompile": "^5.0.0",
-            "broccoli-debug": "^0.6.5",
-            "broccoli-persistent-filter": "^3.1.2",
-            "broccoli-plugin": "^4.0.3",
-            "common-tags": "^1.8.0",
-            "ember-cli-babel-plugin-helpers": "^1.1.1",
-            "ember-cli-version-checker": "^5.1.2",
-            "fs-tree-diff": "^2.0.1",
-            "hash-for-dep": "^1.5.1",
-            "heimdalljs-logger": "^0.1.10",
-            "json-stable-stringify": "^1.0.1",
-            "semver": "^7.3.4",
-            "silent-error": "^1.1.1",
-            "strip-bom": "^4.0.0",
-            "walk-sync": "^2.2.0"
-          }
-        },
-        "fs-tree-diff": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
-          "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
-          "dev": true,
-          "requires": {
-            "@types/symlink-or-copy": "^1.2.0",
-            "heimdalljs-logger": "^0.1.7",
-            "object-assign": "^4.1.0",
-            "path-posix": "^1.0.0",
-            "symlink-or-copy": "^1.1.8"
-          }
-        },
-        "istextorbinary": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz",
-          "integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
-          "dev": true,
-          "requires": {
-            "binaryextensions": "^2.1.2",
-            "editions": "^2.2.0",
-            "textextensions": "^2.5.0"
-          }
-        },
-        "minimist": {
-          "version": "1.2.6",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-          "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-          "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.6"
-          }
-        },
-        "rsvp": {
-          "version": "4.8.5",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-          "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-          "dev": true
-        },
-        "strip-bom": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-          "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
-          "dev": true
-        },
-        "walk-sync": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-          "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-          "dev": true,
-          "requires": {
-            "@types/minimatch": "^3.0.3",
-            "ensure-posix-path": "^1.1.0",
-            "matcher-collection": "^2.0.0",
-            "minimatch": "^3.0.4"
+            "@embroider/macros": "^1.13.0",
+            "broccoli-funnel": "^3.0.5",
+            "ember-cli-babel": "^7.26.11"
           }
         }
       }
@@ -44149,18 +43870,41 @@
       }
     },
     "@embroider/macros": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-1.8.3.tgz",
-      "integrity": "sha512-gnIOfTL/pUkoD6oI7JyWOqXlVIUgZM+CnbH10/YNtZr2K0hij9eZQMdgjOZZVgN0rKOFw9dIREqc1ygrJHRYQA==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-1.13.1.tgz",
+      "integrity": "sha512-4htraP/rNIht8uCxXoc59Bw2EsBFfc4YUQD9XSpzJ4xUr1V0GQf9wL/noeSuYSxIhwRfZOErnJhsdyf1hH+I/A==",
       "requires": {
-        "@embroider/shared-internals": "1.8.3",
+        "@embroider/shared-internals": "2.4.0",
         "assert-never": "^1.2.1",
-        "babel-import-util": "^1.1.0",
+        "babel-import-util": "^2.0.0",
         "ember-cli-babel": "^7.26.6",
         "find-up": "^5.0.0",
         "lodash": "^4.17.21",
         "resolve": "^1.20.0",
         "semver": "^7.3.2"
+      },
+      "dependencies": {
+        "@embroider/shared-internals": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-2.4.0.tgz",
+          "integrity": "sha512-pFE05ebenWMC9XAPRjadYCXXb6VmqjkhYN5uqkhPo+VUmMHnx7sZYYxqGjxfVuhC/ghS/BNlOffOCXDOoE7k7g==",
+          "requires": {
+            "babel-import-util": "^2.0.0",
+            "debug": "^4.3.2",
+            "ember-rfc176-data": "^0.3.17",
+            "fs-extra": "^9.1.0",
+            "js-string-escape": "^1.0.1",
+            "lodash": "^4.17.21",
+            "resolve-package-path": "^4.0.1",
+            "semver": "^7.3.5",
+            "typescript-memoize": "^1.0.1"
+          }
+        },
+        "babel-import-util": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/babel-import-util/-/babel-import-util-2.0.0.tgz",
+          "integrity": "sha512-pkWynbLwru0RZmA9iKeQL63+CkkW0RCP3kL5njCtudd6YPUKb5Pa0kL4fb3bmuKn2QDBFwY5mvvhEK/+jv2Ynw=="
+        }
       }
     },
     "@embroider/shared-internals": {
@@ -44853,8 +44597,7 @@
     "@glimmer/env": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/@glimmer/env/-/env-0.1.7.tgz",
-      "integrity": "sha512-JKF/a9I9jw6fGoz8kA7LEQslrwJ5jms5CXhu/aqkBWk+PmZ6pTl8mlb/eJ/5ujBGTiQzBhy5AIWF712iA+4/mw==",
-      "dev": true
+      "integrity": "sha512-JKF/a9I9jw6fGoz8kA7LEQslrwJ5jms5CXhu/aqkBWk+PmZ6pTl8mlb/eJ/5ujBGTiQzBhy5AIWF712iA+4/mw=="
     },
     "@glimmer/global-context": {
       "version": "0.83.1",
@@ -45079,8 +44822,7 @@
     "@handlebars/parser": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@handlebars/parser/-/parser-2.0.0.tgz",
-      "integrity": "sha512-EP9uEDZv/L5Qh9IWuMUGJRfwhXJ4h1dqKTT4/3+tY0eu7sPis7xh23j61SYUnNF4vqCQvvUXpDo9Bh/+q1zASA==",
-      "dev": true
+      "integrity": "sha512-EP9uEDZv/L5Qh9IWuMUGJRfwhXJ4h1dqKTT4/3+tY0eu7sPis7xh23j61SYUnNF4vqCQvvUXpDo9Bh/+q1zASA=="
     },
     "@humanwhocodes/config-array": {
       "version": "0.5.0",
@@ -45259,8 +45001,7 @@
     "@simple-dom/interface": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@simple-dom/interface/-/interface-1.4.0.tgz",
-      "integrity": "sha512-l5qumKFWU0S+4ZzMaLXFU8tQZsicHEMEyAxI5kDFGhJsRqDwe0a7/iPA/GdxlGyDKseQQAgIz5kzU7eXTrlSpA==",
-      "dev": true
+      "integrity": "sha512-l5qumKFWU0S+4ZzMaLXFU8tQZsicHEMEyAxI5kDFGhJsRqDwe0a7/iPA/GdxlGyDKseQQAgIz5kzU7eXTrlSpA=="
     },
     "@simple-dom/parser": {
       "version": "1.4.0",
@@ -45615,19 +45356,6 @@
       "dev": true,
       "requires": {
         "@types/ember__application": "^3"
-      }
-    },
-    "@types/ember__test-helpers": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@types/ember__test-helpers/-/ember__test-helpers-2.8.0.tgz",
-      "integrity": "sha512-lAnpTPmGNuocrJiIxFP6pkMWhEeTmrqsa4yBKjaBBxDXWF1qh3CCWEr/Tj7oe7HVUyL7w53mxyPIjskvCyiEBw==",
-      "dev": true,
-      "requires": {
-        "@types/ember__application": "*",
-        "@types/ember__error": "*",
-        "@types/ember__test-helpers": "*",
-        "@types/ember-resolver": "*",
-        "@types/htmlbars-inline-precompile": "*"
       }
     },
     "@types/ember__utils": {
@@ -47055,23 +46783,47 @@
       }
     },
     "babel-plugin-ember-template-compilation": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-ember-template-compilation/-/babel-plugin-ember-template-compilation-1.0.2.tgz",
-      "integrity": "sha512-4HBMksmlYsWEf/C/n3uW5rkBRbUp4FNaspzdQTAHgLbfCJnkLze8R6i6sUSge48y/Wne7mx+vcImI1o6rlUwXQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-ember-template-compilation/-/babel-plugin-ember-template-compilation-2.2.0.tgz",
+      "integrity": "sha512-1I7f5gf06h5wKdKUvaYEIaoSFur5RLUvTMQG4ak0c5Y11DWUxcoX9hrun1xe9fqfY2dtGFK+ZUM6sn6z8sqK/w==",
       "requires": {
-        "babel-import-util": "^1.2.0",
-        "line-column": "^1.0.2",
-        "magic-string": "^0.26.0",
-        "string.prototype.matchall": "^4.0.5"
+        "@glimmer/syntax": "^0.84.3",
+        "babel-import-util": "^2.0.0"
       },
       "dependencies": {
-        "magic-string": {
-          "version": "0.26.2",
-          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.2.tgz",
-          "integrity": "sha512-NzzlXpclt5zAbmo6h6jNc8zl2gNRGHvmsZW4IvZhTC4W7k4OlLP+S5YLussa/r3ixNT66KOQfNORlXHSOy/X4A==",
+        "@glimmer/interfaces": {
+          "version": "0.84.3",
+          "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.84.3.tgz",
+          "integrity": "sha512-dk32ykoNojt0mvEaIW6Vli5MGTbQo58uy3Epj7ahCgTHmWOKuw/0G83f2UmFprRwFx689YTXG38I/vbpltEjzg==",
           "requires": {
-            "sourcemap-codec": "^1.4.8"
+            "@simple-dom/interface": "^1.4.0"
           }
+        },
+        "@glimmer/syntax": {
+          "version": "0.84.3",
+          "resolved": "https://registry.npmjs.org/@glimmer/syntax/-/syntax-0.84.3.tgz",
+          "integrity": "sha512-ioVbTic6ZisLxqTgRBL2PCjYZTFIwobifCustrozRU2xGDiYvVIL0vt25h2c1ioDsX59UgVlDkIK4YTAQQSd2A==",
+          "requires": {
+            "@glimmer/interfaces": "0.84.3",
+            "@glimmer/util": "0.84.3",
+            "@handlebars/parser": "~2.0.0",
+            "simple-html-tokenizer": "^0.5.11"
+          }
+        },
+        "@glimmer/util": {
+          "version": "0.84.3",
+          "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.84.3.tgz",
+          "integrity": "sha512-qFkh6s16ZSRuu2rfz3T4Wp0fylFj3HBsONGXQcrAdZjdUaIS6v3pNj6mecJ71qRgcym9Hbaq/7/fefIwECUiKw==",
+          "requires": {
+            "@glimmer/env": "0.1.7",
+            "@glimmer/interfaces": "0.84.3",
+            "@simple-dom/interface": "^1.4.0"
+          }
+        },
+        "babel-import-util": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/babel-import-util/-/babel-import-util-2.0.0.tgz",
+          "integrity": "sha512-pkWynbLwru0RZmA9iKeQL63+CkkW0RCP3kL5njCtudd6YPUKb5Pa0kL4fb3bmuKn2QDBFwY5mvvhEK/+jv2Ynw=="
         }
       }
     },
@@ -51957,12 +51709,12 @@
       "dev": true
     },
     "ember-cli-htmlbars": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-6.1.0.tgz",
-      "integrity": "sha512-kT+MA2JsNLk10HpxAjpB5HHtR0WCoxZEUwLsy/BBww5lXmsrf34QzmTw7SL6DabZVxs+YCb9RhU9KTmFygGxCg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-6.3.0.tgz",
+      "integrity": "sha512-N9Y80oZfcfWLsqickMfRd9YByVcTGyhYRnYQ2XVPVrp6jyUyOeRWmEAPh7ERSXpp8Ws4hr/JB9QVQrn/yZa+Ag==",
       "requires": {
         "@ember/edition-utils": "^1.2.0",
-        "babel-plugin-ember-template-compilation": "^1.0.0",
+        "babel-plugin-ember-template-compilation": "^2.0.0",
         "babel-plugin-htmlbars-inline-precompile": "^5.3.0",
         "broccoli-debug": "^0.6.5",
         "broccoli-persistent-filter": "^3.1.2",
@@ -73187,8 +72939,7 @@
     "simple-html-tokenizer": {
       "version": "0.5.11",
       "resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.5.11.tgz",
-      "integrity": "sha512-C2WEK/Z3HoSFbYq8tI7ni3eOo/NneSPRoPpcM7WdLjFOArFuyXEjAoCdOC3DgMfRyziZQ1hCNR4mrNdWEvD0og==",
-      "dev": true
+      "integrity": "sha512-C2WEK/Z3HoSFbYq8tI7ni3eOo/NneSPRoPpcM7WdLjFOArFuyXEjAoCdOC3DgMfRyziZQ1hCNR4mrNdWEvD0og=="
     },
     "sinon": {
       "version": "9.2.4",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
-    "@ember/test-helpers": "~2.7.0",
+    "@ember/test-helpers": "^2.9.0",
     "@embroider/test-setup": "^1.6.0",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
@@ -59,7 +59,6 @@
     "@types/ember__string": "^3.16.3",
     "@types/ember__template": "^3.16.1",
     "@types/ember__test": "^3.16.1",
-    "@types/ember__test-helpers": "^2.0.2",
     "@types/ember__utils": "^3.16.2",
     "@types/ember-data": "^3.16.15",
     "@types/ember-data__adapter": "^3.16.1",


### PR DESCRIPTION
`@ember/test-helpers` has supplied its own type definitions since [2.9.0](https://github.com/emberjs/ember-test-helpers/releases/tag/v2.9.0)