### PR TITLE
Fix `ModelRegistry` type issues that arise when `any` is removed from registry

### DIFF
--- a/addon/adapters/cloud-firestore-modular.ts
+++ b/addon/adapters/cloud-firestore-modular.ts
@@ -10,6 +10,7 @@ import Adapter from '@ember-data/adapter';
 import DS from 'ember-data';
 import RSVP from 'rsvp';
 import Store from '@ember-data/store';
+import ModelRegistry from 'ember-data/types/registries/model';
 
 import {
   CollectionReference,
@@ -34,9 +35,9 @@ import FirestoreDataManager from 'ember-cloud-firestore-adapter/services/-firest
 import buildCollectionName from 'ember-cloud-firestore-adapter/-private/build-collection-name';
 import flattenDocSnapshot from 'ember-cloud-firestore-adapter/-private/flatten-doc-snapshot';
 
-interface ModelClass {
-  modelName: string;
-}
+type ModelClass<K extends keyof ModelRegistry> = ModelRegistry[K] & {
+  modelName: K;
+};
 
 interface AdapterOption {
   isRealtime?: boolean;
@@ -53,7 +54,7 @@ interface Snapshot extends DS.Snapshot {
   adapterOptions: AdapterOption;
 }
 
-interface SnapshotRecordArray extends DS.SnapshotRecordArray<string | number> {
+interface SnapshotRecordArray<K extends keyof ModelRegistry> extends DS.SnapshotRecordArray<K> {
   adapterOptions: AdapterOption;
 }
 
@@ -63,7 +64,7 @@ interface BelongsToRelationshipMeta {
 }
 
 interface HasManyRelationshipMeta {
-  key: string;
+  key: keyof ModelRegistry;
   type: string;
   options: {
     isRealtime?: boolean,
@@ -85,6 +86,7 @@ export default class CloudFirestoreModularAdapter extends Adapter {
     return fastboot && fastboot.isFastBoot;
   }
 
+  // @ts-ignore
   public generateIdForRecord(_store: Store, type: string): string {
     const db = getFirestore();
     const collectionName = buildCollectionName(type);
@@ -92,17 +94,17 @@ export default class CloudFirestoreModularAdapter extends Adapter {
     return doc(collection(db, collectionName)).id;
   }
 
-  public createRecord(
+  public createRecord<K extends keyof ModelRegistry>(
     store: Store,
-    type: ModelClass,
+    type: ModelClass<K>,
     snapshot: Snapshot,
   ): RSVP.Promise<unknown> {
     return this.updateRecord(store, type, snapshot);
   }
 
-  public updateRecord(
+  public updateRecord<K extends keyof ModelRegistry>(
     _store: Store,
-    type: ModelClass,
+    type: ModelClass<K>,
     snapshot: Snapshot,
   ): RSVP.Promise<unknown> {
     return new RSVP.Promise((resolve, reject) => {
@@ -125,9 +127,9 @@ export default class CloudFirestoreModularAdapter extends Adapter {
     });
   }
 
-  public deleteRecord(
+  public deleteRecord<K extends keyof ModelRegistry>(
     _store: Store,
-    type: ModelClass,
+    type: ModelClass<K>,
     snapshot: Snapshot,
   ): RSVP.Promise<unknown> {
     return new RSVP.Promise((resolve, reject) => {
@@ -147,9 +149,9 @@ export default class CloudFirestoreModularAdapter extends Adapter {
     });
   }
 
-  public findRecord(
+  public findRecord<K extends keyof ModelRegistry>(
     _store: Store,
-    type: ModelClass,
+    type: ModelClass<K>,
     id: string,
     snapshot: Snapshot,
   ): RSVP.Promise<unknown> {
@@ -172,11 +174,11 @@ export default class CloudFirestoreModularAdapter extends Adapter {
     });
   }
 
-  public findAll(
+  public findAll<K extends keyof ModelRegistry>(
     _store: Store,
-    type: ModelClass,
+    type: ModelClass<K>,
     _sinceToken: string,
-    snapshotRecordArray?: SnapshotRecordArray,
+    snapshotRecordArray?: SnapshotRecordArray<K>,
   ): RSVP.Promise<unknown> {
     return new RSVP.Promise(async (resolve, reject) => {
       try {
@@ -195,9 +197,9 @@ export default class CloudFirestoreModularAdapter extends Adapter {
     });
   }
 
-  public query(
+  public query<K extends keyof ModelRegistry>(
     _store: Store,
-    type: ModelClass,
+    type: ModelClass<K>,
     queryOption: AdapterOption,
     recordArray: DS.AdapterPopulatedRecordArray<unknown>,
   ): RSVP.Promise<unknown> {
@@ -334,10 +336,20 @@ export default class CloudFirestoreModularAdapter extends Adapter {
       return relationship.options.filter?.(collectionRef, snapshot.record) || collectionRef;
     }
 
-    const cardinality = snapshot.type.determineRelationshipType(relationship, store);
+    const cardinality = (
+      snapshot.type as unknown as {
+        determineRelationshipType: (
+          _relationship: HasManyRelationshipMeta,
+          _store: Store
+        ) => string;
+      }
+    ).determineRelationshipType(relationship, store);
 
     if (cardinality === 'manyToOne') {
-      const inverse = snapshot.type.inverseFor(relationship.key, store);
+      const inverse = (snapshot.type as unknown as typeof DS.Model).inverseFor(
+        relationship.key,
+        store,
+      ) as { name: string; };
       const snapshotCollectionName = buildCollectionName(snapshot.modelName.toString());
       const snapshotDocRef = doc(db, `${snapshotCollectionName}/${snapshot.id}`);
       const collectionRef = collection(db, url);

--- a/types/ember-data/types/registries/model.d.ts
+++ b/types/ember-data/types/registries/model.d.ts
@@ -1,8 +1,6 @@
-/* eslint @typescript-eslint/no-explicit-any: off */
+/* eslint @typescript-eslint/no-empty-interface: off */
 
 /**
  * Catch-all for ember-data.
  */
-export default interface ModelRegistry {
-  [key: string]: any;
-}
+export default interface ModelRegistry {}


### PR DESCRIPTION
## Problem

In TypeScript apps that consume this addon, removing the `[key: string]: any;` entry that is included by default in `ModelRegstry` (`types/ember-data/types/registries/model.d.ts`) reveals some type errors in the adapter:

![Screenshot 2023-09-25 121235](https://github.com/mikkopaderes/ember-cloud-firestore-adapter/assets/2275005/946f7d45-b2e0-4f41-ad4d-1f1971b6d092)

## Solution

Use generic `keyof ModelRegistry` for `modelName` on `ModelClass` and update usage.

