### PR TITLE
chore: pass `Store` service objects in tests

### DIFF
--- a/tests/unit/adapters/cloud-firestore-modular-test.ts
+++ b/tests/unit/adapters/cloud-firestore-modular-test.ts
@@ -31,10 +31,11 @@ module('Unit | Adapter | cloud firestore modular', function (hooks) {
   module('function: generateIdForRecord', function () {
     test('should generate ID for record', function (assert) {
       // Arrange
+      const store = this.owner.lookup('service:store');
       const adapter = this.owner.lookup('adapter:cloud-firestore-modular');
 
       // Act
-      const result = adapter.generateIdForRecord({}, 'foo');
+      const result = adapter.generateIdForRecord(store, 'foo');
 
       // Assert
       assert.strictEqual(typeof result, 'string');
@@ -44,7 +45,7 @@ module('Unit | Adapter | cloud firestore modular', function (hooks) {
   module('function: createRecord', function () {
     test('should proxy a call to updateRecord and return with the created doc', async function (assert) {
       // Arrange
-      const store = {};
+      const store = this.owner.lookup('service:store');
       const modelClass = { modelName: 'user' };
       const snapshot = { id: 'user_100', age: 30, username: 'user_100' };
       const adapter = this.owner.lookup('adapter:cloud-firestore-modular');
@@ -63,7 +64,7 @@ module('Unit | Adapter | cloud firestore modular', function (hooks) {
   module('function: updateRecord', function () {
     test('should update record and resolve with the updated doc', async function (assert) {
       // Arrange
-      const store = {};
+      const store = this.owner.lookup('service:store');
       const modelClass = { modelName: 'user' };
       const snapshot = {
         id: 'user_a',
@@ -90,7 +91,7 @@ module('Unit | Adapter | cloud firestore modular', function (hooks) {
 
     test('should update record in a custom collection and resolve with the updated resource', async function (assert) {
       // Arrange
-      const store = {};
+      const store = this.owner.lookup('service:store');
       const modelClass = { modelName: 'user' };
       const snapshot = {
         id: 'user_a',
@@ -118,7 +119,7 @@ module('Unit | Adapter | cloud firestore modular', function (hooks) {
 
     test('should update record and process additional batched writes', async function (assert) {
       // Arrange
-      const store = {};
+      const store = this.owner.lookup('service:store');
       const modelClass = { modelName: 'user' };
       const snapshot = {
         id: 'user_a',
@@ -153,7 +154,7 @@ module('Unit | Adapter | cloud firestore modular', function (hooks) {
   module('function: deleteRecord', function () {
     test('should delete record', async function (assert) {
       // Arrange
-      const store = {};
+      const store = this.owner.lookup('service:store');
       const modelClass = { modelName: 'user' };
       const snapshot = { id: 'user_a' };
       const adapter = this.owner.lookup('adapter:cloud-firestore-modular');
@@ -169,7 +170,7 @@ module('Unit | Adapter | cloud firestore modular', function (hooks) {
 
     test('should delete record in a custom collection', async function (assert) {
       // Arrange
-      const store = {};
+      const store = this.owner.lookup('service:store');
       const modelClass = { modelName: 'post' };
       const snapshot = {
         id: 'post_b',
@@ -193,7 +194,7 @@ module('Unit | Adapter | cloud firestore modular', function (hooks) {
 
     test('should delete record and process additional batched writes', async function (assert) {
       // Arrange
-      const store = {};
+      const store = this.owner.lookup('service:store');
       const modelClass = { modelName: 'user' };
       const snapshot = {
         id: 'user_a',
@@ -224,7 +225,9 @@ module('Unit | Adapter | cloud firestore modular', function (hooks) {
   module('function: findAll', function () {
     test('should fetch all records for a model', async function (assert) {
       // Arrange
-      const store = { normalize: sinon.stub(), push: sinon.stub() };
+      const store = this.owner.lookup('service:store');
+      store.normalize = sinon.stub();
+      store.push = sinon.stub();
       const modelClass = { modelName: 'user' };
       const adapter = this.owner.lookup('adapter:cloud-firestore-modular');
 
@@ -258,7 +261,9 @@ module('Unit | Adapter | cloud firestore modular', function (hooks) {
   module('function: findRecord', function () {
     test('should fetch a record', async function (assert) {
       // Arrange
-      const store = { normalize: sinon.stub(), push: sinon.stub() };
+      const store = this.owner.lookup('service:store');
+      store.normalize = sinon.stub();
+      store.push = sinon.stub();
       const modelClass = { modelName: 'user' };
       const modelId = 'user_a';
       const snapshot = {};
@@ -278,7 +283,9 @@ module('Unit | Adapter | cloud firestore modular', function (hooks) {
 
     test('should fetch a record in a custom collection', async function (assert) {
       // Arrange
-      const store = { normalize: sinon.stub(), push: sinon.stub() };
+      const store = this.owner.lookup('service:store');
+      store.normalize = sinon.stub();
+      store.push = sinon.stub();
       const modelClass = { modelName: 'user' };
       const modelId = 'user_a';
       const snapshot = {
@@ -301,7 +308,9 @@ module('Unit | Adapter | cloud firestore modular', function (hooks) {
       // Arrange
       assert.expect(2);
 
-      const store = { normalize: sinon.stub(), push: sinon.stub() };
+      const store = this.owner.lookup('service:store');
+      store.normalize = sinon.stub();
+      store.push = sinon.stub();
       const modelClass = { modelName: 'user' };
       const modelId = 'user_100';
       const snapshot = {};
@@ -321,7 +330,9 @@ module('Unit | Adapter | cloud firestore modular', function (hooks) {
   module('function: findBelongsTo', function () {
     test('should fetch a belongs to record', async function (assert) {
       // Arrange
-      const store = { normalize: sinon.stub(), push: sinon.stub() };
+      const store = this.owner.lookup('service:store');
+      store.normalize = sinon.stub();
+      store.push = sinon.stub();
       const snapshot = {};
       const url = 'users/user_a';
       const relationship = { type: 'user', options: {} };
@@ -343,7 +354,9 @@ module('Unit | Adapter | cloud firestore modular', function (hooks) {
   module('function: findHasMany', function () {
     test('should fetch many-to-one cardinality', async function (assert) {
       // Arrange
-      const store = { normalize: sinon.stub(), push: sinon.stub() };
+      const store = this.owner.lookup('service:store');
+      store.normalize = sinon.stub();
+      store.push = sinon.stub();
       const determineRelationshipTypeStub = sinon.stub().returns('manyToOne');
       const inverseForStub = sinon.stub().returns({ name: 'author' });
       const snapshot = {
@@ -379,7 +392,9 @@ module('Unit | Adapter | cloud firestore modular', function (hooks) {
 
     test('should fetch many-to-whatever cardinality', async function (assert) {
       // Arrange
-      const store = { normalize: sinon.stub(), push: sinon.stub() };
+      const store = this.owner.lookup('service:store');
+      store.normalize = sinon.stub();
+      store.push = sinon.stub();
       const determineRelationshipTypeStub = sinon.stub().returns('manyToNone');
       const snapshot = {
         record: EmberObject.create({
@@ -417,7 +432,9 @@ module('Unit | Adapter | cloud firestore modular', function (hooks) {
 
     test('should be able to fetch with filter using a record property', async function (assert) {
       // Arrange
-      const store = { normalize: sinon.stub(), push: sinon.stub() };
+      const store = this.owner.lookup('service:store');
+      store.normalize = sinon.stub();
+      store.push = sinon.stub();
       const determineRelationshipTypeStub = sinon.stub().returns('manyToOne');
       const inverseForStub = sinon.stub().returns({ name: 'author' });
       const snapshot = {
@@ -455,7 +472,9 @@ module('Unit | Adapter | cloud firestore modular', function (hooks) {
 
     test('should be able to fetch with a custom reference', async function (assert) {
       // Arrange
-      const store = { normalize: sinon.stub(), push: sinon.stub() };
+      const store = this.owner.lookup('service:store');
+      store.normalize = sinon.stub();
+      store.push = sinon.stub();
       const snapshot = {
         record: EmberObject.create({ id: 'user_a' }),
       };
@@ -487,7 +506,7 @@ module('Unit | Adapter | cloud firestore modular', function (hooks) {
   module('function: query', function () {
     test('should query for records', async function (assert) {
       // Arrange
-      const store = {};
+      const store = this.owner.lookup('service:store');
       const modelClass = { modelName: 'user' };
       const queryRef = {
         filter(reference: CollectionReference) {
@@ -512,7 +531,7 @@ module('Unit | Adapter | cloud firestore modular', function (hooks) {
 
     test('should query for records in a custom collection', async function (assert) {
       // Arrange
-      const store = {};
+      const store = this.owner.lookup('service:store');
       const modelClass = { modelName: 'user' };
       const queryRef = {
         buildReference(firestore: Firestore) {


### PR DESCRIPTION
Passes actual `Store` objects in tests instead of `{}`. Left unchanged these lines will become TS errors when EmberData TS types are updated.