### PR TITLE
fix: remove `snapshot.type` usage to fix `ember-data:deprecate-snapshot-model-class-access` deprecation

### DIFF
--- a/addon/adapters/cloud-firestore-modular.ts
+++ b/addon/adapters/cloud-firestore-modular.ts
@@ -334,10 +334,11 @@ export default class CloudFirestoreModularAdapter extends Adapter {
       return relationship.options.filter?.(collectionRef, snapshot.record) || collectionRef;
     }
 
-    const cardinality = snapshot.type.determineRelationshipType(relationship, store);
+    const modelClass = store.modelFor(snapshot.modelName);
+    const cardinality = modelClass.determineRelationshipType(relationship, store);
 
     if (cardinality === 'manyToOne') {
-      const inverse = snapshot.type.inverseFor(relationship.key, store);
+      const inverse = modelClass.inverseFor(relationship.key, store);
       const snapshotCollectionName = buildCollectionName(snapshot.modelName.toString());
       const snapshotDocRef = doc(db, `${snapshotCollectionName}/${snapshot.id}`);
       const collectionRef = collection(db, url);


### PR DESCRIPTION
https://deprecations.emberjs.com/ember-data/v4.x/#toc_ember-data-deprecate-snapshot-model-class-access