### PR TITLE
chore: fix serializer `extractRelationships` types, expose adapter properties

### DIFF
--- a/addon/adapters/cloud-firestore-modular.ts
+++ b/addon/adapters/cloud-firestore-modular.ts
@@ -72,11 +72,11 @@ interface HasManyRelationshipMeta {
 
 export default class CloudFirestoreModularAdapter extends Adapter {
   @service('-firestore-data-manager')
-  private declare firestoreDataManager: FirestoreDataManager;
+  protected declare firestoreDataManager: FirestoreDataManager;
 
   protected referenceKeyName = 'referenceTo';
 
-  private get isFastBoot(): boolean {
+  protected get isFastBoot(): boolean {
     const fastboot = getOwner(this).lookup('service:fastboot');
 
     return fastboot && fastboot.isFastBoot;

--- a/addon/adapters/cloud-firestore-modular.ts
+++ b/addon/adapters/cloud-firestore-modular.ts
@@ -35,7 +35,7 @@ import FirestoreDataManager from 'ember-cloud-firestore-adapter/services/-firest
 import buildCollectionName from 'ember-cloud-firestore-adapter/-private/build-collection-name';
 import flattenDocSnapshot from 'ember-cloud-firestore-adapter/-private/flatten-doc-snapshot';
 
-interface AdapterOption {
+export interface AdapterOption {
   isRealtime?: boolean;
   queryId?: string;
 

--- a/addon/adapters/cloud-firestore-modular.ts
+++ b/addon/adapters/cloud-firestore-modular.ts
@@ -282,7 +282,7 @@ export default class CloudFirestoreModularAdapter extends Adapter {
     });
   }
 
-  private buildCollectionRef(
+  protected buildCollectionRef(
     modelName: keyof ModelRegistry,
     adapterOptions?: AdapterOption,
   ): CollectionReference {

--- a/addon/serializers/cloud-firestore-modular.ts
+++ b/addon/serializers/cloud-firestore-modular.ts
@@ -6,7 +6,7 @@
 */
 
 import { isNone } from '@ember/utils';
-import DS from 'ember-data';
+import DS, { ModelSchema } from 'ember-data';
 import JSONSerializer from '@ember-data/serializer/json';
 import Store from '@ember-data/store';
 
@@ -33,43 +33,8 @@ interface RelationshipDefinition {
   };
 }
 
-interface RelationshipSchema {
-  name: string;
-  kind: 'belongsTo' | 'hasMany';
-  type: string;
-  options: {
-    async: boolean;
-    polymorphic?: boolean;
-    as?: string;
-    inverse: string | null;
-    [key: string]: unknown;
-  };
-}
-
-interface AttributeSchema {
-  name: string;
-  kind?: 'attribute';
-  options?: Record<string, unknown>;
-  type?: string;
-}
-
-interface ModelClass {
-  modelName: string;
-  fields: Map<string, 'attribute' | 'belongsTo' | 'hasMany'>;
-  attributes: Map<string, AttributeSchema>;
-  relationshipsByName: Map<string, RelationshipSchema>;
-  eachAttribute<T>(
-    callback: (this: T, key: string, attribute: AttributeSchema) => void,
-    binding?: T
-  ): void;
-  eachTransformedAttribute<T>(
-    callback: (this: T, key: string, relationship: RelationshipSchema) => void,
-    binding?: T
-  ): void;
+type ModelClass = ModelSchema & {
   determineRelationshipType(descriptor: { kind: string, type: string }, store: Store): string;
-  eachRelationship<T>(callback: (this: T, name: string, descriptor: RelationshipSchema) => void,
-    binding?: T
-  ): void;
 }
 
 export default class CloudFirestoreSerializer extends JSONSerializer {
@@ -105,7 +70,7 @@ export default class CloudFirestoreSerializer extends JSONSerializer {
         if (cardinality === 'manyToOne') {
           hasManyPath = buildCollectionName(descriptor.type);
         } else {
-          const collectionName = buildCollectionName(modelClass.modelName);
+          const collectionName = buildCollectionName(modelClass.modelName as string);
           const docId = resourceHash.id;
 
           hasManyPath = `${collectionName}/${docId}/${name}`;


### PR DESCRIPTION
- Update serializer `extractRelationships` method to use `ModelSchema` and `{ determineRelationshipType(descriptor: { kind: string, type: string }, store: Store): string; }` intersection type
- Expose some adapter types and properties to make subclassing easier