### PR TITLE
chore: support `ember-simple-auth` v6

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -5,7 +5,6 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 module.exports = function (defaults) {
   const app = new EmberAddon(defaults, {
     'ember-cli-babel': { includePolyfill: true },
-    'ember-simple-auth': { useSessionSetupMethod: true },
   });
 
   /*

--- a/package-lock.json
+++ b/package-lock.json
@@ -100,7 +100,7 @@
       },
       "peerDependencies": {
         "ember-auto-import": "2.x",
-        "ember-simple-auth": "4.x || 5.x",
+        "ember-simple-auth": "4.x || 5.x || 6.x",
         "firebase": "9.14.x"
       }
     },

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
   },
   "peerDependencies": {
     "ember-auto-import": "2.x",
-    "ember-simple-auth": "4.x || 5.x",
+    "ember-simple-auth": "4.x || 5.x || 6.x",
     "firebase": "9.14.x"
   },
   "engines": {


### PR DESCRIPTION
- Support `ember-simple-auth` v6 in `peerDependencies`
- Remove unused build setting that opts out of ESA initializer