### PR TITLE
fix!: export `AdapterRecordNotFoundError` as default

### DIFF
--- a/addon/adapters/cloud-firestore-modular.ts
+++ b/addon/adapters/cloud-firestore-modular.ts
@@ -24,7 +24,7 @@ import {
   where,
   writeBatch,
 } from 'ember-cloud-firestore-adapter/firebase/firestore';
-import { AdapterRecordNotFoundError } from 'ember-cloud-firestore-adapter/utils/custom-errors';
+import AdapterRecordNotFoundError from 'ember-cloud-firestore-adapter/utils/custom-errors';
 import FirestoreDataManager from 'ember-cloud-firestore-adapter/services/-firestore-data-manager';
 import buildCollectionName from 'ember-cloud-firestore-adapter/-private/build-collection-name';
 import flattenDocSnapshot from 'ember-cloud-firestore-adapter/-private/flatten-doc-snapshot';

--- a/addon/utils/custom-errors.ts
+++ b/addon/utils/custom-errors.ts
@@ -1,6 +1,4 @@
-/* eslint-disable import/prefer-default-export */
-
-export class AdapterRecordNotFoundError extends Error {
+export default class AdapterRecordNotFoundError extends Error {
   public cause: string | undefined;
 
   constructor(message?: string, options?: { cause: string }) {

--- a/docs/finding-records.md
+++ b/docs/finding-records.md
@@ -45,7 +45,7 @@ Hook for providing a custom collection reference on where you want to fetch the 
 When finding a single record, you can catch for `AdapterRecordNotFoundError` error when the record doesn't exist.
 
 ```javascript
-import { AdapterRecordNotFoundError } from 'ember-cloud-firestore-adapter/utils/custom-errors';
+import AdapterRecordNotFoundError from 'ember-cloud-firestore-adapter/utils/custom-errors';
 
 this.store.findRecord('user', 'user_1').then((record) => {
   // Do something

--- a/tests/unit/adapters/cloud-firestore-modular-test.ts
+++ b/tests/unit/adapters/cloud-firestore-modular-test.ts
@@ -20,7 +20,7 @@ import {
   query,
   where,
 } from 'ember-cloud-firestore-adapter/firebase/firestore';
-import { AdapterRecordNotFoundError } from 'ember-cloud-firestore-adapter/utils/custom-errors';
+import AdapterRecordNotFoundError from 'ember-cloud-firestore-adapter/utils/custom-errors';
 import resetFixtureData from '../../helpers/reset-fixture-data';
 
 module('Unit | Adapter | cloud firestore modular', function (hooks) {

--- a/tests/unit/utils/custom-errors-test.ts
+++ b/tests/unit/utils/custom-errors-test.ts
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 
-import { AdapterRecordNotFoundError } from 'ember-cloud-firestore-adapter/utils/custom-errors';
+import AdapterRecordNotFoundError from 'ember-cloud-firestore-adapter/utils/custom-errors';
 
 module('Unit | Utility | custom-errors', function () {
   module('class: AdapterRecordNotFoundError', function () {


### PR DESCRIPTION
Fixes #305 

This is a breaking change.

I opted to export `AdapterRecordNotFoundError` as default instead of modifying the generated re-export files in `app` . `custom-errors` only contains one export currently.

