### PR TITLE
chore: update `ember-simple-auth` in test app

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -5,7 +5,6 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 module.exports = function (defaults) {
   const app = new EmberAddon(defaults, {
     'ember-cli-babel': { includePolyfill: true },
-    'ember-simple-auth': { useSessionSetupMethod: true },
 
     // Add options here
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
       "devDependencies": {
         "@ember/optional-features": "^2.1.0",
         "@ember/test-helpers": "^2.9.0",
-        "@embroider/test-setup": "^1.6.0",
+        "@embroider/test-setup": "^3.0.3",
         "@glimmer/component": "^1.1.2",
         "@glimmer/tracking": "^1.1.2",
         "@types/ember": "^4.0.11",
@@ -3931,9 +3931,9 @@
       }
     },
     "node_modules/@embroider/test-setup": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@embroider/test-setup/-/test-setup-1.8.3.tgz",
-      "integrity": "sha512-BCCbBG7UWkCw+cQ401Ip6LnqTRaQDeKImxR+e7Q4oP6H4EBj7p4iGR1z6fhMy4NNyXKPB6jk3bGa9bTiiNoEAw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@embroider/test-setup/-/test-setup-3.0.3.tgz",
+      "integrity": "sha512-3K5KSyTdnxAkZQill6+TdC/XTRr6226LNwZMsrhRbBM0FFZXw2D8qmJSHPvZLheQx3A1jnF9t1lyrAzrKlg6Yw==",
       "dev": true,
       "dependencies": {
         "lodash": "^4.17.21",
@@ -3941,6 +3941,22 @@
       },
       "engines": {
         "node": "12.* || 14.* || >= 16"
+      },
+      "peerDependencies": {
+        "@embroider/compat": "^3.3.0",
+        "@embroider/core": "^3.4.0",
+        "@embroider/webpack": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "@embroider/compat": {
+          "optional": true
+        },
+        "@embroider/core": {
+          "optional": true
+        },
+        "@embroider/webpack": {
+          "optional": true
+        }
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -46908,9 +46924,9 @@
       }
     },
     "@embroider/test-setup": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@embroider/test-setup/-/test-setup-1.8.3.tgz",
-      "integrity": "sha512-BCCbBG7UWkCw+cQ401Ip6LnqTRaQDeKImxR+e7Q4oP6H4EBj7p4iGR1z6fhMy4NNyXKPB6jk3bGa9bTiiNoEAw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@embroider/test-setup/-/test-setup-3.0.3.tgz",
+      "integrity": "sha512-3K5KSyTdnxAkZQill6+TdC/XTRr6226LNwZMsrhRbBM0FFZXw2D8qmJSHPvZLheQx3A1jnF9t1lyrAzrKlg6Yw==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "ember-page-title": "^7.0.0",
         "ember-qunit": "^5.1.5",
         "ember-resolver": "^8.0.3",
-        "ember-simple-auth": "^4.2.2",
+        "ember-simple-auth": "^6.0.0",
         "ember-sinon": "^5.0.0",
         "ember-source": "~4.4.0",
         "ember-source-channel-url": "^3.0.0",
@@ -3494,6 +3494,51 @@
       },
       "engines": {
         "node": "10.* || 12.* || >= 14.*"
+      }
+    },
+    "node_modules/@embroider/addon-shim": {
+      "version": "1.8.9",
+      "resolved": "https://registry.npmjs.org/@embroider/addon-shim/-/addon-shim-1.8.9.tgz",
+      "integrity": "sha512-qyN64T1jMHZ99ihlk7VFHCWHYZHLE1DOdHi0J7lmn5waV1DoW7gD8JLi1i7FregzXtKhbDc7shyEmTmWPTs8MQ==",
+      "dev": true,
+      "dependencies": {
+        "@embroider/shared-internals": "^2.6.0",
+        "broccoli-funnel": "^3.0.8",
+        "common-ancestor-path": "^1.0.1",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": "12.* || 14.* || >= 16"
+      }
+    },
+    "node_modules/@embroider/addon-shim/node_modules/@embroider/shared-internals": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-2.6.1.tgz",
+      "integrity": "sha512-STU1oDP36JQY+zpivyAfXGXadN664d+DOiVNBUW+4AAuWLVxIRWDIuFj8UxzREXZU9trZY8vOhKwKQtfEgdwSg==",
+      "dev": true,
+      "dependencies": {
+        "babel-import-util": "^2.0.0",
+        "debug": "^4.3.2",
+        "ember-rfc176-data": "^0.3.17",
+        "fs-extra": "^9.1.0",
+        "js-string-escape": "^1.0.1",
+        "lodash": "^4.17.21",
+        "minimatch": "^3.0.4",
+        "resolve-package-path": "^4.0.1",
+        "semver": "^7.3.5",
+        "typescript-memoize": "^1.0.1"
+      },
+      "engines": {
+        "node": "12.* || 14.* || >= 16"
+      }
+    },
+    "node_modules/@embroider/addon-shim/node_modules/babel-import-util": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/babel-import-util/-/babel-import-util-2.1.1.tgz",
+      "integrity": "sha512-3qBQWRjzP9NreSH/YrOEU1Lj5F60+pWSLP0kIdCWxjFHH7pX2YPHIxQ67el4gnMNfYoDxSDGcT0zpVlZ+gVtQA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12.*"
       }
     },
     "node_modules/@embroider/macros": {
@@ -8054,12 +8099,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/base-64": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
-      "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA==",
-      "dev": true
-    },
     "node_modules/base/node_modules/define-property": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
@@ -11219,6 +11258,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/common-ancestor-path": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz",
+      "integrity": "sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==",
+      "dev": true
     },
     "node_modules/common-tags": {
       "version": "1.8.2",
@@ -14539,16 +14584,15 @@
       }
     },
     "node_modules/ember-cookies": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-0.5.2.tgz",
-      "integrity": "sha512-nZ7oG97kBcO9UHjO95ryABpnVx62Bhxo7lIsBJNmWvFXleILm9DGueiAynzXxuYWWPuKIeeSbYakrS1869tNTw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-1.1.2.tgz",
+      "integrity": "sha512-6GaN0eEDZT9SEUSZBxWzZMlvxjcGKXFTJNjv30LVXTTOxozE5IBmIxiDAEq0udi0UpWUGHLYQBgnANn4jdll7w==",
       "dev": true,
       "dependencies": {
-        "ember-cli-babel": "^7.1.0",
-        "ember-getowner-polyfill": "^1.1.0 || ^2.0.0"
+        "@embroider/addon-shim": "^1.7.1"
       },
       "engines": {
-        "node": "8.* || 10.* || >= 12.*"
+        "node": ">= 16.*"
       }
     },
     "node_modules/ember-data": {
@@ -14757,40 +14801,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/ember-factory-for-polyfill": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/ember-factory-for-polyfill/-/ember-factory-for-polyfill-1.3.1.tgz",
-      "integrity": "sha512-y3iG2iCzH96lZMTWQw6LWNLAfOmDC4pXKbZP6FxG8lt7GGaNFkZjwsf+Z5GAe7kxfD7UG4lVkF7x37K82rySGA==",
-      "dev": true,
-      "dependencies": {
-        "ember-cli-version-checker": "^2.1.0"
-      },
-      "engines": {
-        "node": "^4.5 || 6.* || >= 7.*"
-      }
-    },
-    "node_modules/ember-factory-for-polyfill/node_modules/ember-cli-version-checker": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
-      "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-      "dev": true,
-      "dependencies": {
-        "resolve": "^1.3.3",
-        "semver": "^5.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/ember-factory-for-polyfill/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
     "node_modules/ember-fetch": {
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/ember-fetch/-/ember-fetch-8.1.2.tgz",
@@ -14941,41 +14951,6 @@
       },
       "bin": {
         "rollup": "bin/rollup"
-      }
-    },
-    "node_modules/ember-getowner-polyfill": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ember-getowner-polyfill/-/ember-getowner-polyfill-2.2.0.tgz",
-      "integrity": "sha512-rwGMJgbGzxIAiWYjdpAh04Abvt0s3HuS/VjHzUFhVyVg2pzAuz45B9AzOxYXzkp88vFC7FPaiA4kE8NxNk4A4Q==",
-      "dev": true,
-      "dependencies": {
-        "ember-cli-version-checker": "^2.1.0",
-        "ember-factory-for-polyfill": "^1.3.1"
-      },
-      "engines": {
-        "node": "^4.5 || 6.* || >= 7.*"
-      }
-    },
-    "node_modules/ember-getowner-polyfill/node_modules/ember-cli-version-checker": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
-      "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-      "dev": true,
-      "dependencies": {
-        "resolve": "^1.3.3",
-        "semver": "^5.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/ember-getowner-polyfill/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
       }
     },
     "node_modules/ember-inflector": {
@@ -16243,149 +16218,25 @@
       }
     },
     "node_modules/ember-simple-auth": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/ember-simple-auth/-/ember-simple-auth-4.2.2.tgz",
-      "integrity": "sha512-D7W6OREUvf5OzeB0ePptSNBilccchRYukH4f7mkbL6WT+z6VEqRRAIaQuBZdFM6lrcSFGmzctINLZJwsIpI3wg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ember-simple-auth/-/ember-simple-auth-6.0.0.tgz",
+      "integrity": "sha512-9SzSFApxZ74CD4UxIeTV+poIPeXcRLXWM60cMvC1SwTYjoc/p9DeQF0pVm6m1XV6uA3kPUzEsEn4/GeHc2YX1w==",
       "dev": true,
       "dependencies": {
-        "base-64": "^0.1.0",
-        "broccoli-file-creator": "^2.1.1",
-        "broccoli-funnel": "^1.2.0 || ^2.0.0",
-        "broccoli-merge-trees": "^4.0.0",
-        "ember-cli-babel": "^7.20.5",
+        "@ember/test-waiters": "^3",
+        "@embroider/addon-shim": "^1.0.0",
+        "@embroider/macros": "^1.0.0",
         "ember-cli-is-package-missing": "^1.0.0",
-        "ember-cookies": "^0.5.0",
+        "ember-cookies": "^1.0.0",
         "silent-error": "^1.0.0"
       },
-      "engines": {
-        "node": ">= 12"
-      },
       "peerDependencies": {
-        "ember-fetch": "^8.0.1"
-      }
-    },
-    "node_modules/ember-simple-auth/node_modules/broccoli-funnel": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
-      "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
-      "dev": true,
-      "dependencies": {
-        "array-equal": "^1.0.0",
-        "blank-object": "^1.0.1",
-        "broccoli-plugin": "^1.3.0",
-        "debug": "^2.2.0",
-        "fast-ordered-set": "^1.0.0",
-        "fs-tree-diff": "^0.5.3",
-        "heimdalljs": "^0.2.0",
-        "minimatch": "^3.0.0",
-        "mkdirp": "^0.5.0",
-        "path-posix": "^1.0.0",
-        "rimraf": "^2.4.3",
-        "symlink-or-copy": "^1.0.0",
-        "walk-sync": "^0.3.1"
+        "@ember/test-helpers": ">= 3 || > 2.7"
       },
-      "engines": {
-        "node": "^4.5 || 6.* || >= 7.*"
-      }
-    },
-    "node_modules/ember-simple-auth/node_modules/broccoli-merge-trees": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-4.2.0.tgz",
-      "integrity": "sha512-nTrQe5AQtCrW4enLRvbD/vTLHqyW2tz+vsLXQe4IEaUhepuMGVKJJr+I8n34Vu6fPjmPLwTjzNC8izMIDMtHPw==",
-      "dev": true,
-      "dependencies": {
-        "broccoli-plugin": "^4.0.2",
-        "merge-trees": "^2.0.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-simple-auth/node_modules/broccoli-merge-trees/node_modules/broccoli-plugin": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
-      "integrity": "sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==",
-      "dev": true,
-      "dependencies": {
-        "broccoli-node-api": "^1.7.0",
-        "broccoli-output-wrapper": "^3.2.5",
-        "fs-merger": "^3.2.1",
-        "promise-map-series": "^0.3.0",
-        "quick-temp": "^0.1.8",
-        "rimraf": "^3.0.2",
-        "symlink-or-copy": "^1.3.1"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-simple-auth/node_modules/broccoli-merge-trees/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/ember-simple-auth/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/ember-simple-auth/node_modules/minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true
-    },
-    "node_modules/ember-simple-auth/node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/ember-simple-auth/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true
-    },
-    "node_modules/ember-simple-auth/node_modules/promise-map-series": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.3.0.tgz",
-      "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==",
-      "dev": true,
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-simple-auth/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
+      "peerDependenciesMeta": {
+        "@ember/test-helpers": {
+          "optional": true
+        }
       }
     },
     "node_modules/ember-sinon": {
@@ -46722,6 +46573,44 @@
         "semver": "^7.3.5"
       }
     },
+    "@embroider/addon-shim": {
+      "version": "1.8.9",
+      "resolved": "https://registry.npmjs.org/@embroider/addon-shim/-/addon-shim-1.8.9.tgz",
+      "integrity": "sha512-qyN64T1jMHZ99ihlk7VFHCWHYZHLE1DOdHi0J7lmn5waV1DoW7gD8JLi1i7FregzXtKhbDc7shyEmTmWPTs8MQ==",
+      "dev": true,
+      "requires": {
+        "@embroider/shared-internals": "^2.6.0",
+        "broccoli-funnel": "^3.0.8",
+        "common-ancestor-path": "^1.0.1",
+        "semver": "^7.3.8"
+      },
+      "dependencies": {
+        "@embroider/shared-internals": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-2.6.1.tgz",
+          "integrity": "sha512-STU1oDP36JQY+zpivyAfXGXadN664d+DOiVNBUW+4AAuWLVxIRWDIuFj8UxzREXZU9trZY8vOhKwKQtfEgdwSg==",
+          "dev": true,
+          "requires": {
+            "babel-import-util": "^2.0.0",
+            "debug": "^4.3.2",
+            "ember-rfc176-data": "^0.3.17",
+            "fs-extra": "^9.1.0",
+            "js-string-escape": "^1.0.1",
+            "lodash": "^4.17.21",
+            "minimatch": "^3.0.4",
+            "resolve-package-path": "^4.0.1",
+            "semver": "^7.3.5",
+            "typescript-memoize": "^1.0.1"
+          }
+        },
+        "babel-import-util": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/babel-import-util/-/babel-import-util-2.1.1.tgz",
+          "integrity": "sha512-3qBQWRjzP9NreSH/YrOEU1Lj5F60+pWSLP0kIdCWxjFHH7pX2YPHIxQ67el4gnMNfYoDxSDGcT0zpVlZ+gVtQA==",
+          "dev": true
+        }
+      }
+    },
     "@embroider/macros": {
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-1.16.0.tgz",
@@ -50640,12 +50529,6 @@
         }
       }
     },
-    "base-64": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
-      "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA==",
-      "dev": true
-    },
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -53246,6 +53129,12 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true
+    },
+    "common-ancestor-path": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz",
+      "integrity": "sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==",
       "dev": true
     },
     "common-tags": {
@@ -55983,13 +55872,12 @@
       }
     },
     "ember-cookies": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-0.5.2.tgz",
-      "integrity": "sha512-nZ7oG97kBcO9UHjO95ryABpnVx62Bhxo7lIsBJNmWvFXleILm9DGueiAynzXxuYWWPuKIeeSbYakrS1869tNTw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-1.1.2.tgz",
+      "integrity": "sha512-6GaN0eEDZT9SEUSZBxWzZMlvxjcGKXFTJNjv30LVXTTOxozE5IBmIxiDAEq0udi0UpWUGHLYQBgnANn4jdll7w==",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "^7.1.0",
-        "ember-getowner-polyfill": "^1.1.0 || ^2.0.0"
+        "@embroider/addon-shim": "^1.7.1"
       }
     },
     "ember-data": {
@@ -56148,33 +56036,6 @@
       "integrity": "sha512-B7wiurPgsxsSGzJuPFkpBWnaeuCu2PGpG2BjyrfA1VcL7//o+5RSnZqiCEY326y7qmxb2GoCgo0ft03KBU0rRw==",
       "dev": true
     },
-    "ember-factory-for-polyfill": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/ember-factory-for-polyfill/-/ember-factory-for-polyfill-1.3.1.tgz",
-      "integrity": "sha512-y3iG2iCzH96lZMTWQw6LWNLAfOmDC4pXKbZP6FxG8lt7GGaNFkZjwsf+Z5GAe7kxfD7UG4lVkF7x37K82rySGA==",
-      "dev": true,
-      "requires": {
-        "ember-cli-version-checker": "^2.1.0"
-      },
-      "dependencies": {
-        "ember-cli-version-checker": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
-          "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-          "dev": true,
-          "requires": {
-            "resolve": "^1.3.3",
-            "semver": "^5.3.0"
-          }
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
-      }
-    },
     "ember-fetch": {
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/ember-fetch/-/ember-fetch-8.1.2.tgz",
@@ -56297,34 +56158,6 @@
             "signal-exit": "^3.0.2",
             "sourcemap-codec": "^1.4.1"
           }
-        }
-      }
-    },
-    "ember-getowner-polyfill": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ember-getowner-polyfill/-/ember-getowner-polyfill-2.2.0.tgz",
-      "integrity": "sha512-rwGMJgbGzxIAiWYjdpAh04Abvt0s3HuS/VjHzUFhVyVg2pzAuz45B9AzOxYXzkp88vFC7FPaiA4kE8NxNk4A4Q==",
-      "dev": true,
-      "requires": {
-        "ember-cli-version-checker": "^2.1.0",
-        "ember-factory-for-polyfill": "^1.3.1"
-      },
-      "dependencies": {
-        "ember-cli-version-checker": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
-          "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-          "dev": true,
-          "requires": {
-            "resolve": "^1.3.3",
-            "semver": "^5.3.0"
-          }
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
         }
       }
     },
@@ -57358,123 +57191,17 @@
       }
     },
     "ember-simple-auth": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/ember-simple-auth/-/ember-simple-auth-4.2.2.tgz",
-      "integrity": "sha512-D7W6OREUvf5OzeB0ePptSNBilccchRYukH4f7mkbL6WT+z6VEqRRAIaQuBZdFM6lrcSFGmzctINLZJwsIpI3wg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ember-simple-auth/-/ember-simple-auth-6.0.0.tgz",
+      "integrity": "sha512-9SzSFApxZ74CD4UxIeTV+poIPeXcRLXWM60cMvC1SwTYjoc/p9DeQF0pVm6m1XV6uA3kPUzEsEn4/GeHc2YX1w==",
       "dev": true,
       "requires": {
-        "base-64": "^0.1.0",
-        "broccoli-file-creator": "^2.1.1",
-        "broccoli-funnel": "^1.2.0 || ^2.0.0",
-        "broccoli-merge-trees": "^4.0.0",
-        "ember-cli-babel": "^7.20.5",
+        "@ember/test-waiters": "^3",
+        "@embroider/addon-shim": "^1.0.0",
+        "@embroider/macros": "^1.0.0",
         "ember-cli-is-package-missing": "^1.0.0",
-        "ember-cookies": "^0.5.0",
+        "ember-cookies": "^1.0.0",
         "silent-error": "^1.0.0"
-      },
-      "dependencies": {
-        "broccoli-funnel": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
-          "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
-          "dev": true,
-          "requires": {
-            "array-equal": "^1.0.0",
-            "blank-object": "^1.0.1",
-            "broccoli-plugin": "^1.3.0",
-            "debug": "^2.2.0",
-            "fast-ordered-set": "^1.0.0",
-            "fs-tree-diff": "^0.5.3",
-            "heimdalljs": "^0.2.0",
-            "minimatch": "^3.0.0",
-            "mkdirp": "^0.5.0",
-            "path-posix": "^1.0.0",
-            "rimraf": "^2.4.3",
-            "symlink-or-copy": "^1.0.0",
-            "walk-sync": "^0.3.1"
-          }
-        },
-        "broccoli-merge-trees": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-4.2.0.tgz",
-          "integrity": "sha512-nTrQe5AQtCrW4enLRvbD/vTLHqyW2tz+vsLXQe4IEaUhepuMGVKJJr+I8n34Vu6fPjmPLwTjzNC8izMIDMtHPw==",
-          "dev": true,
-          "requires": {
-            "broccoli-plugin": "^4.0.2",
-            "merge-trees": "^2.0.0"
-          },
-          "dependencies": {
-            "broccoli-plugin": {
-              "version": "4.0.7",
-              "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
-              "integrity": "sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==",
-              "dev": true,
-              "requires": {
-                "broccoli-node-api": "^1.7.0",
-                "broccoli-output-wrapper": "^3.2.5",
-                "fs-merger": "^3.2.1",
-                "promise-map-series": "^0.3.0",
-                "quick-temp": "^0.1.8",
-                "rimraf": "^3.0.2",
-                "symlink-or-copy": "^1.3.1"
-              }
-            },
-            "rimraf": {
-              "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-              "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-              "dev": true,
-              "requires": {
-                "glob": "^7.1.3"
-              }
-            }
-          }
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "minimist": {
-          "version": "1.2.6",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-          "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-          "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.6"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-          "dev": true
-        },
-        "promise-map-series": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.3.0.tgz",
-          "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==",
-          "dev": true
-        },
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        }
       }
     },
     "ember-sinon": {

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "ember-page-title": "^7.0.0",
     "ember-qunit": "^5.1.5",
     "ember-resolver": "^8.0.3",
-    "ember-simple-auth": "^4.2.2",
+    "ember-simple-auth": "^6.0.0",
     "ember-sinon": "^5.0.0",
     "ember-source": "~4.4.0",
     "ember-source-channel-url": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@ember/optional-features": "^2.1.0",
     "@ember/test-helpers": "^2.9.0",
-    "@embroider/test-setup": "^1.6.0",
+    "@embroider/test-setup": "^3.0.3",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
     "@types/ember": "^4.0.11",


### PR DESCRIPTION
Fixes error that occurs after `ember-data` update:

```
Global error: Uncaught Error: Could not find module `@ember/polyfills` imported from `ember-simple-auth/utils/assign`
```

Also updates `@embroider/test-setup` to fix Embroider errors related to `ember-cookies`:

```
ModuleNotFoundError: Module not found: Error: Can't resolve 'ember-cookies/services/cookies'
```