### PR TITLE
fix: add crypto to `fastbootDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,8 @@
   "ember-addon": {
     "configPath": "tests/dummy/config",
     "fastbootDependencies": [
-      "firebase"
+      "firebase",
+      "crypto"
     ]
   }
 }


### PR DESCRIPTION
- Fixes FastBoot error in test app
- First occurred after EmberData update