### PR TITLE
Fix array proxy deprecation

### DIFF
--- a/tests/dummy/app/controllers/features.ts
+++ b/tests/dummy/app/controllers/features.ts
@@ -90,7 +90,8 @@ export default class FeaturesController extends Controller {
   @action
   public async handleDeleteRecordClick(): Promise<void> {
     const users = await this.store.findAll('user');
-    const user = users.get('firstObject');
+    // @ts-expect-error array proxy is indeed indexable
+    const user = users[0];
 
     await user?.destroyRecord();
 


### PR DESCRIPTION
```
DEPRECATION: The EmberObject get method on the class RecordArray is deprecated. Use dot-notation javascript get/set access instead. [deprecation id: ember-data:deprecate-array-like] This will be removed in ember-data 5.0.

DEPRECATION: The `firstObject` method on the class RecordArray is deprecated. Use the native array method `[0]` instead. [deprecation id: ember-data:deprecate-array-like] This will be removed in ember-data 5.0.
```