### PR TITLE
chore: export adapter types, fix adapter test arrangements

### DIFF
--- a/addon/adapters/cloud-firestore-modular.ts
+++ b/addon/adapters/cloud-firestore-modular.ts
@@ -56,13 +56,13 @@ export interface SnapshotRecordArray extends _SnapshotRecordArray {
   adapterOptions: AdapterOption;
 }
 
-type LegacyBelongsToField = _LegacyBelongsToField & {
+export type LegacyBelongsToField = _LegacyBelongsToField & {
   options: {
     isRealtime?: boolean;
   };
 };
 
-type LegacyHasManyField = _LegacyHasManyField & {
+export type LegacyHasManyField = _LegacyHasManyField & {
   key: string;
   options: {
     isRealtime?: boolean;

--- a/addon/adapters/cloud-firestore-modular.ts
+++ b/addon/adapters/cloud-firestore-modular.ts
@@ -7,8 +7,8 @@ import type { Snapshot as _Snapshot } from '@ember-data/legacy-compat/legacy-net
 import type { SnapshotRecordArray as _SnapshotRecordArray } from '@ember-data/legacy-compat/-private';
 import type { Collection } from '@ember-data/store/-private/record-arrays/identifier-array';
 import type {
-  LegacyBelongsToField,
-  LegacyHasManyField,
+  LegacyBelongsToField as _LegacyBelongsToField,
+  LegacyHasManyField as _LegacyHasManyField,
 } from '@warp-drive/core-types/schema/fields';
 import type Model from 'ember-data/model';
 import RSVP from 'rsvp';
@@ -48,19 +48,21 @@ export interface AdapterOption {
   [key: string]: unknown;
 }
 
-interface Snapshot extends _Snapshot {
+export interface Snapshot extends _Snapshot {
   adapterOptions: AdapterOption;
 }
 
-interface SnapshotRecordArray extends _SnapshotRecordArray {
+export interface SnapshotRecordArray extends _SnapshotRecordArray {
   adapterOptions: AdapterOption;
 }
 
-type BelongsToRelationshipMeta = LegacyBelongsToField & {
-  options: { isRealtime?: boolean };
+type LegacyBelongsToField = _LegacyBelongsToField & {
+  options: {
+    isRealtime?: boolean;
+  };
 };
 
-type HasManyRelationshipMeta = LegacyHasManyField & {
+type LegacyHasManyField = _LegacyHasManyField & {
   key: string;
   options: {
     isRealtime?: boolean;
@@ -82,9 +84,9 @@ export default class CloudFirestoreAdapter extends Adapter {
     return !!fastboot && fastboot.isFastBoot;
   }
 
-  public generateIdForRecord(_store: Store, type: unknown): string {
+  public generateIdForRecord(_store: Store, type: string): string {
     const db = getFirestore();
-    const collectionName = buildCollectionName(type as string); // TODO: EmberData types incorrect
+    const collectionName = buildCollectionName(type);
 
     return doc(collection(db, collectionName)).id;
   }
@@ -268,7 +270,7 @@ export default class CloudFirestoreAdapter extends Adapter {
     _store: Store,
     _snapshot: Snapshot,
     url: string,
-    relationship: BelongsToRelationshipMeta,
+    relationship: LegacyBelongsToField,
   ): Promise<AdapterPayload> {
     return new RSVP.Promise(async (resolve, reject) => {
       try {
@@ -307,7 +309,7 @@ export default class CloudFirestoreAdapter extends Adapter {
     store: Store,
     snapshot: Snapshot,
     url: string,
-    relationship: HasManyRelationshipMeta,
+    relationship: LegacyHasManyField,
   ): Promise<AdapterPayload> {
     return new RSVP.Promise(async (resolve, reject) => {
       try {
@@ -391,7 +393,7 @@ export default class CloudFirestoreAdapter extends Adapter {
     store: Store,
     snapshot: Snapshot,
     url: string,
-    relationship: HasManyRelationshipMeta,
+    relationship: LegacyHasManyField,
   ): CollectionReference | Query {
     const db = getFirestore();
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "lint:hbs:fix": "ember-template-lint . --fix",
     "lint:js": "eslint . --cache",
     "lint:js:fix": "eslint . --fix",
+    "lint:types": "tsc --noEmit",
     "prepack": "npm run build:wrappers && tsc --project tsconfig.declarations.json",
     "postpack": "rimraf declarations",
     "start": "npm run build:wrappers && firebase emulators:exec --import=./emulator-data --project ember-cloud-firestore-adapter-test-project --ui \"ember serve\"",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "lint:hbs:fix": "ember-template-lint . --fix",
     "lint:js": "eslint . --cache",
     "lint:js:fix": "eslint . --fix",
-    "lint:types": "tsc --noEmit",
     "prepack": "npm run build:wrappers && tsc --project tsconfig.declarations.json",
     "postpack": "rimraf declarations",
     "start": "npm run build:wrappers && firebase emulators:exec --import=./emulator-data --project ember-cloud-firestore-adapter-test-project --ui \"ember serve\"",

--- a/tests/dummy/app/models/user.ts
+++ b/tests/dummy/app/models/user.ts
@@ -16,6 +16,9 @@ export default class UserModel extends Model {
   @attr('number')
   public declare age: number;
 
+  @attr('string')
+  public declare username: string;
+
   @hasMany('group', { async: true, inverse: 'members' })
   public declare groups: AsyncHasMany<GroupModel>;
 

--- a/tests/unit/adapters/cloud-firestore-modular-test.ts
+++ b/tests/unit/adapters/cloud-firestore-modular-test.ts
@@ -62,7 +62,7 @@ module('Unit | Adapter | cloud firestore modular', function (hooks) {
     test('should proxy a call to updateRecord and return with the created doc', async function (assert) {
       // Arrange
       const store = this.owner.lookup('service:store');
-      const modelClass = { modelName: 'user' } as ModelSchema;
+      const modelClass = store.modelFor('user');
       const snapshot = { id: 'user_100', age: 30, username: 'user_100' };
       const adapter = this.owner.lookup(
         'adapter:cloud-firestore-modular',
@@ -91,7 +91,7 @@ module('Unit | Adapter | cloud firestore modular', function (hooks) {
     test('should update record and resolve with the updated doc', async function (assert) {
       // Arrange
       const store = this.owner.lookup('service:store');
-      const modelClass = { modelName: 'user' } as ModelSchema;
+      const modelClass = store.modelFor('user');
       const snapshot = {
         id: 'user_a',
         age: 50,
@@ -124,7 +124,7 @@ module('Unit | Adapter | cloud firestore modular', function (hooks) {
     test('should update record in a custom collection and resolve with the updated resource', async function (assert) {
       // Arrange
       const store = this.owner.lookup('service:store');
-      const modelClass = { modelName: 'user' } as ModelSchema;
+      const modelClass = store.modelFor('user');
       const snapshot = {
         id: 'user_a',
         age: 50,
@@ -158,7 +158,7 @@ module('Unit | Adapter | cloud firestore modular', function (hooks) {
     test('should update record and process additional batched writes', async function (assert) {
       // Arrange
       const store = this.owner.lookup('service:store');
-      const modelClass = { modelName: 'user' } as ModelSchema;
+      const modelClass = store.modelFor('user');
       const snapshot = {
         id: 'user_a',
         age: 50,
@@ -203,7 +203,7 @@ module('Unit | Adapter | cloud firestore modular', function (hooks) {
     test('should delete record', async function (assert) {
       // Arrange
       const store = this.owner.lookup('service:store');
-      const modelClass = { modelName: 'user' } as ModelSchema;
+      const modelClass = store.modelFor('user');
       const snapshot = { id: 'user_a' };
       const adapter = this.owner.lookup(
         'adapter:cloud-firestore-modular',
@@ -221,7 +221,7 @@ module('Unit | Adapter | cloud firestore modular', function (hooks) {
     test('should delete record in a custom collection', async function (assert) {
       // Arrange
       const store = this.owner.lookup('service:store');
-      const modelClass = { modelName: 'post' } as ModelSchema;
+      const modelClass = store.modelFor('post');
       const snapshot = {
         id: 'post_b',
 
@@ -247,7 +247,7 @@ module('Unit | Adapter | cloud firestore modular', function (hooks) {
     test('should delete record and process additional batched writes', async function (assert) {
       // Arrange
       const store = this.owner.lookup('service:store');
-      const modelClass = { modelName: 'user' } as ModelSchema;
+      const modelClass = store.modelFor('user');
       const snapshot = {
         id: 'user_a',
         adapterOptions: {
@@ -282,7 +282,7 @@ module('Unit | Adapter | cloud firestore modular', function (hooks) {
       const store = this.owner.lookup('service:store');
       store.normalize = sinon.stub();
       (store.push as (data: EmptyResourceDocument) => null) = sinon.stub();
-      const modelClass = { modelName: 'user' } as ModelSchema;
+      const modelClass = store.modelFor('user');
       const adapter = this.owner.lookup(
         'adapter:cloud-firestore-modular',
       ) as CloudFirestoreModularAdapter;
@@ -320,7 +320,7 @@ module('Unit | Adapter | cloud firestore modular', function (hooks) {
       const store = this.owner.lookup('service:store');
       store.normalize = sinon.stub();
       (store.push as (data: EmptyResourceDocument) => null) = sinon.stub();
-      const modelClass = { modelName: 'user' } as ModelSchema;
+      const modelClass = store.modelFor('user');
       const modelId = 'user_a';
       const snapshot = {};
       const adapter = this.owner.lookup(
@@ -349,7 +349,7 @@ module('Unit | Adapter | cloud firestore modular', function (hooks) {
       const store = this.owner.lookup('service:store');
       store.normalize = sinon.stub();
       (store.push as (data: EmptyResourceDocument) => null) = sinon.stub();
-      const modelClass = { modelName: 'user' } as ModelSchema;
+      const modelClass = store.modelFor('user');
       const modelId = 'user_a';
       const snapshot = {
         adapterOptions: {
@@ -381,7 +381,7 @@ module('Unit | Adapter | cloud firestore modular', function (hooks) {
       const store = this.owner.lookup('service:store');
       store.normalize = sinon.stub();
       (store.push as (data: EmptyResourceDocument) => null) = sinon.stub();
-      const modelClass = { modelName: 'user' } as ModelSchema;
+      const modelClass = store.modelFor('user');
       const modelId = 'user_100';
       const snapshot = {};
       const adapter = this.owner.lookup(
@@ -648,7 +648,7 @@ module('Unit | Adapter | cloud firestore modular', function (hooks) {
     test('should query for records', async function (assert) {
       // Arrange
       const store = this.owner.lookup('service:store');
-      const modelClass = { modelName: 'user' } as ModelSchema;
+      const modelClass = store.modelFor('user');
       const queryRef = {
         filter(reference: CollectionReference) {
           return query(reference, where('age', '>=', 15), limit(1));
@@ -680,7 +680,7 @@ module('Unit | Adapter | cloud firestore modular', function (hooks) {
     test('should query for records in a custom collection', async function (assert) {
       // Arrange
       const store = this.owner.lookup('service:store');
-      const modelClass = { modelName: 'user' } as ModelSchema;
+      const modelClass = store.modelFor('user');
       const queryRef = {
         buildReference(firestore: Firestore) {
           return collection(firestore, 'admins');

--- a/tests/unit/adapters/cloud-firestore-modular-test.ts
+++ b/tests/unit/adapters/cloud-firestore-modular-test.ts
@@ -29,6 +29,8 @@ import {
 } from 'ember-cloud-firestore-adapter/firebase/firestore';
 import type CloudFirestoreModularAdapter from 'ember-cloud-firestore-adapter/adapters/cloud-firestore-modular';
 import AdapterRecordNotFoundError from 'ember-cloud-firestore-adapter/utils/custom-errors';
+import type { Snapshot } from 'ember-cloud-firestore-adapter/adapters/cloud-firestore-modular';
+import type UserModel from 'dummy/tests/dummy/app/models/user';
 import resetFixtureData from '../../helpers/reset-fixture-data';
 
 module('Unit | Adapter | cloud firestore modular', function (hooks) {
@@ -63,7 +65,13 @@ module('Unit | Adapter | cloud firestore modular', function (hooks) {
       // Arrange
       const store = this.owner.lookup('service:store');
       const modelClass = store.modelFor('user');
-      const snapshot = { id: 'user_100', age: 30, username: 'user_100' };
+      const snapshot = store
+        .createRecord<UserModel>('user', {
+          id: 'user_100',
+          age: 30,
+          username: 'user_100',
+        })
+        ._createSnapshot() as Snapshot;
       const adapter = this.owner.lookup(
         'adapter:cloud-firestore-modular',
       ) as CloudFirestoreModularAdapter;
@@ -73,16 +81,12 @@ module('Unit | Adapter | cloud firestore modular', function (hooks) {
         .returns(Promise.resolve({ foo: 'foo' }));
 
       // Act
-      const result = await adapter.createRecord(
-        store,
-        modelClass,
-        snapshot as any,
-      );
+      const result = await adapter.createRecord(store, modelClass, snapshot);
 
       // Assert
       assert.deepEqual(result, { foo: 'foo' });
       assert.ok(
-        updateRecordStub.calledWithExactly(store, modelClass, snapshot as any),
+        updateRecordStub.calledWithExactly(store, modelClass, snapshot),
       );
     });
   });
@@ -92,10 +96,12 @@ module('Unit | Adapter | cloud firestore modular', function (hooks) {
       // Arrange
       const store = this.owner.lookup('service:store');
       const modelClass = store.modelFor('user');
-      const snapshot = {
-        id: 'user_a',
-        age: 50,
-      };
+      const snapshot = store
+        .createRecord<UserModel>('user', {
+          id: 'user_a',
+          age: 50,
+        })
+        ._createSnapshot() as Snapshot;
       const adapter = this.owner.lookup(
         'adapter:cloud-firestore-modular',
       ) as CloudFirestoreModularAdapter;
@@ -106,11 +112,7 @@ module('Unit | Adapter | cloud firestore modular', function (hooks) {
       });
 
       // Act
-      const result = await adapter.updateRecord(
-        store,
-        modelClass,
-        snapshot as any,
-      );
+      const result = await adapter.updateRecord(store, modelClass, snapshot);
 
       // Assert
       assert.deepEqual(result, { age: 50, username: 'user_a' });
@@ -204,13 +206,15 @@ module('Unit | Adapter | cloud firestore modular', function (hooks) {
       // Arrange
       const store = this.owner.lookup('service:store');
       const modelClass = store.modelFor('user');
-      const snapshot = { id: 'user_a' };
+      const snapshot = store
+        .createRecord<UserModel>('user', { id: 'user_a' })
+        ._createSnapshot() as Snapshot;
       const adapter = this.owner.lookup(
         'adapter:cloud-firestore-modular',
       ) as CloudFirestoreModularAdapter;
 
       // Act
-      await adapter.deleteRecord(store, modelClass, snapshot as any);
+      await adapter.deleteRecord(store, modelClass, snapshot);
 
       // Assert
       const userA = await getDoc(doc(db, 'users/user_a'));
@@ -322,7 +326,9 @@ module('Unit | Adapter | cloud firestore modular', function (hooks) {
       (store.push as (data: EmptyResourceDocument) => null) = sinon.stub();
       const modelClass = store.modelFor('user');
       const modelId = 'user_a';
-      const snapshot = {};
+      const snapshot = store
+        .createRecord<UserModel>('user', {})
+        ._createSnapshot() as Snapshot;
       const adapter = this.owner.lookup(
         'adapter:cloud-firestore-modular',
       ) as CloudFirestoreModularAdapter;
@@ -332,7 +338,7 @@ module('Unit | Adapter | cloud firestore modular', function (hooks) {
         store,
         modelClass,
         modelId,
-        snapshot as any,
+        snapshot,
       );
 
       // Assert
@@ -383,14 +389,16 @@ module('Unit | Adapter | cloud firestore modular', function (hooks) {
       (store.push as (data: EmptyResourceDocument) => null) = sinon.stub();
       const modelClass = store.modelFor('user');
       const modelId = 'user_100';
-      const snapshot = {};
+      const snapshot = store
+        .createRecord<UserModel>('user', {})
+        ._createSnapshot() as Snapshot;
       const adapter = this.owner.lookup(
         'adapter:cloud-firestore-modular',
       ) as CloudFirestoreModularAdapter;
 
       try {
         // Act
-        await adapter.findRecord(store, modelClass, modelId, snapshot as any);
+        await adapter.findRecord(store, modelClass, modelId, snapshot);
       } catch (error) {
         // Assert
         assert.ok(error instanceof AdapterRecordNotFoundError);
@@ -408,7 +416,9 @@ module('Unit | Adapter | cloud firestore modular', function (hooks) {
       const store = this.owner.lookup('service:store');
       store.normalize = sinon.stub();
       (store.push as (data: EmptyResourceDocument) => null) = sinon.stub();
-      const snapshot = {};
+      const snapshot = store
+        .createRecord<UserModel>('user', {})
+        ._createSnapshot() as Snapshot;
       const url = 'users/user_a';
       const relationship = { type: 'user', options: {} };
       const adapter = this.owner.lookup(
@@ -418,7 +428,7 @@ module('Unit | Adapter | cloud firestore modular', function (hooks) {
       // Act
       const result = await adapter.findBelongsTo(
         store,
-        snapshot as any,
+        snapshot,
         url,
         relationship as any,
       );


### PR DESCRIPTION
- Export rest of internal adapter types (these are needed when overriding adapter in host app)
- Use real `modelFor` and `_createSnapshot` fns instead of plain objects in adapter test